### PR TITLE
add space image as driveItem and a trash facet for trash metadata 

### DIFF
--- a/api/openapi-spec/v0.0.yaml
+++ b/api/openapi-spec/v0.0.yaml
@@ -47,7 +47,7 @@ paths:
                 - createdByUser
                 - lastModifiedByUser
                 - root
-                - spaceImage
+                - special
               type: string
             maxItems: 19
         - name: $expand
@@ -62,7 +62,7 @@ paths:
               enum:
                 - '*'
                 - root
-                - spaceImage
+                - special
               type: string
             maxItems: 2
       responses:
@@ -153,7 +153,7 @@ paths:
                 - createdByUser
                 - lastModifiedByUser
                 - root
-                - spaceImage
+                - special
               type: string
             maxItems: 19
         - name: $expand
@@ -168,7 +168,7 @@ paths:
               enum:
                 - '*'
                 - root
-                - spaceImage
+                - special
               type: string
             maxItems: 2
       responses:
@@ -975,8 +975,11 @@ components:
           readOnly: true
         root:
           $ref: '#/components/schemas/driveItem'
-        spaceImage:
-          $ref: '#/components/schemas/driveItem'
+        special:
+          type: array
+          items:
+              $ref: '#/components/schemas/driveItem'
+          description: A collection of special drive resources.
     identitySet:
       type: object
       description: Optional. User account.

--- a/api/openapi-spec/v0.0.yaml
+++ b/api/openapi-spec/v0.0.yaml
@@ -1258,6 +1258,8 @@ components:
           $ref: '#/components/schemas/image'
         root:
           $ref: '#/components/schemas/root'
+        trash:
+          $ref: '#/components/schemas/trash'
         size:
           type: integer
           description: Size of the item in bytes. Read-only.
@@ -1345,6 +1347,20 @@ components:
     root:
       type: object
       description: 'If this property is non-null, it indicates that the driveItem is the top-most driveItem in the drive.'
+    trash:
+      type: object
+      description: 'Metadata for trashed drive Items'
+      readOnly: true
+      properties:
+        trashedBy:
+          $ref: '#/components/schemas/identitySet'
+          description: 'Identity of the user, device, or application which trashed the item. Read-only.'
+          readOnly: true
+        trashedDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: The UTC date and time the folder was marked as trashed.
+          format: date-time
     quota:
       type: object
       description: Optional. Information about the drive's storage space quota. Read-only.

--- a/api/openapi-spec/v0.0.yaml
+++ b/api/openapi-spec/v0.0.yaml
@@ -47,8 +47,9 @@ paths:
                 - createdByUser
                 - lastModifiedByUser
                 - root
+                - spaceImage
               type: string
-            maxItems: 18
+            maxItems: 19
         - name: $expand
           in: query
           description: Expand related entities
@@ -61,6 +62,7 @@ paths:
               enum:
                 - '*'
                 - root
+                - spaceImage
               type: string
             maxItems: 2
       responses:
@@ -151,8 +153,9 @@ paths:
                 - createdByUser
                 - lastModifiedByUser
                 - root
+                - spaceImage
               type: string
-            maxItems: 18
+            maxItems: 19
         - name: $expand
           in: query
           description: Expand related entities
@@ -165,6 +168,7 @@ paths:
               enum:
                 - '*'
                 - root
+                - spaceImage
               type: string
             maxItems: 2
       responses:
@@ -970,6 +974,8 @@ components:
           description: All items contained in the drive. Read-only. Nullable.
           readOnly: true
         root:
+          $ref: '#/components/schemas/driveItem'
+        spaceImage:
           $ref: '#/components/schemas/driveItem'
     identitySet:
       type: object


### PR DESCRIPTION
## Add space image to the graphAPI

related to https://github.com/owncloud/ocis/issues/2661

### Spec

The space Image will be represented as a driveItem on the drive object.

#### Examples

##### Space with image as special drive item
```json
{
  "value": [
    {
      "id": "string",
      "createdBy": {},
      "createdDateTime": "2021-11-24T16:39:06.730Z",
      "description": "string",
      "eTag": "string",
      "lastModifiedBy": {},
      "lastModifiedDateTime": "2021-11-24T16:39:06.730Z",
      "name": "Marketing",
      "webUrl": "string",
      "createdByUser": {},
      "lastModifiedByUser": {},
      "driveType": "project",
      "owner": {},
      "quota": {
        "deleted": 0,
        "remaining": 0,
        "state": "string",
        "total": 0,
        "used": 0
      },
      "special": [{
        "id": "string",
        "createdDateTime": "2021-11-24T16:39:06.730Z",
        "description": "string",
        "eTag": "string",
        "lastModifiedDateTime": "2021-11-24T16:39:06.730Z",
        "name": "spaceImage",
        "webUrl": "string",
        "cTag": "string",
        "deleted": {
          "state": "string"
        },
        "file": {
          "hashes": {
            "crc32Hash": "string",
            "quickXorHash": "string",
            "sha1Hash": "string",
            "sha256Hash": "string"
          },
          "mimeType": "string",
          "processingMetadata": true
        },
        "fileSystemInfo": {
          "createdDateTime": "2021-11-24T16:39:06.730Z",
          "lastAccessedDateTime": "2021-11-24T16:39:06.730Z",
          "lastModifiedDateTime": "2021-11-24T16:39:06.730Z"
        },
        "image": {
          "height": 2147483647,
          "width": 2147483647
        },
      }]
    }
  ]
}
```

## To be discussed

- This only defines the payload of the api
- We need to define which attributes are part of the `GET /me/drives/` request by default and which we will respond when providing the `$extend=image` parameter