### PR TITLE
remove nullable because it is deprecated

### DIFF
--- a/api/openapi-spec/v0.0.yaml
+++ b/api/openapi-spec/v0.0.yaml
@@ -922,16 +922,13 @@ components:
         description:
           type: string
           description: Provides a user-visible description of the item. Optional.
-          nullable: false
         eTag:
           type: string
           description: ETag for the item. Read-only.
-          nullable: false
           readOnly: true
         lastModifiedBy:
           $ref: '#/components/schemas/identitySet'
           description: 'Identity of the user, device, and application which last modified the item. Read-only.'
-          nullable: false
           readOnly: true
         lastModifiedDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
@@ -942,31 +939,25 @@ components:
         name:
           type: string
           description: The name of the item. Read-write.
-          nullable: false
         parentReference:
           $ref: '#/components/schemas/itemReference'
           description: 'Parent information, if the item has a parent. Read-write.'
-          nullable: false
         webUrl:
           type: string
           description: URL that displays the resource in the browser. Read-only.
-          nullable: false
           readOnly: true
         createdByUser:
           $ref: '#/components/schemas/user'
           description: Identity of the user who created the item. Read-only.
-          nullable: false
           readOnly: true
         lastModifiedByUser:
           $ref: '#/components/schemas/user'
           description: Identity of the user who last modified the item. Read-only.
-          nullable: false
           readOnly: true
         # drive
         driveType:
           type: string
           description: Describes the type of drive represented by this resource. Values are "personal" for users home spaces, "project" or "share". Read-only.
-          nullable: false
           readOnly: true
         owner:
           $ref: '#/components/schemas/identitySet'
@@ -987,22 +978,18 @@ components:
         application:
           $ref: '#/components/schemas/identity'
           description: Optional. The application associated with this action.
-          nullable: false
         device:
           $ref: '#/components/schemas/identity'
           description: Optional. The device associated with this action.
-          nullable: false
         user:
           $ref: '#/components/schemas/identity'
           description: Optional. The user associated with this action.
-          nullable: false
     identity:
       type: object
       properties:
         displayName:
           type: string
           description: 'The identity''s display name. Note that this may not always be available or up to date. For example, if a user changes their display name, the API may show the new value in a future response, but the items associated with the user won''t show up as having changed when using delta.'
-          nullable: false
         id:
           type: string
           description: Unique identifier for the identity.
@@ -1020,12 +1007,10 @@ components:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           format: date-time
-          nullable: false
         # user
         accountEnabled:
           type: boolean
           description: 'true if the account is enabled; otherwise, false. This property is required when a user is created. Returned only on $select. Supports $filter.'
-          nullable: false
         businessPhones:
           type: array
           items:
@@ -1034,135 +1019,105 @@ components:
         city:
           type: string
           description: The city in which the user is located. Returned only on $select. Supports $filter.
-          nullable: false
         companyName:
           type: string
           description: The company name which the user is associated. This property can be useful for describing the company that an external user comes from. The maximum length of the company name is 64 characters.Returned only on $select.
-          nullable: false
         country:
           type: string
           description: 'The country/region in which the user is located; for example, ''US'' or ''UK''. Returned only on $select. Supports $filter.'
-          nullable: false
           maxLength: 3
         createdDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           description: The date and time the user was created. The value cannot be modified and is automatically populated when the entity is created. The DateTimeOffset type represents date and time information using ISO 8601 format and is always in UTC time. Property is nullable. A null value indicates that an accurate creation time couldn't be determined for the user. Returned only on $select. Read-only. Supports $filter.
           format: date-time
-          nullable: false
           readOnly: true
         department:
           type: string
           description: The name for the department in which the user works. Returned only on $select. Supports $filter.
-          nullable: false
         displayName:
           type: string
           description: 'The name displayed in the address book for the user. This value is usually the combination of the user''s first name, middle initial, and last name. This property is required when a user is created and it cannot be cleared during updates. Returned by default. Supports $filter and $orderby.'
-          nullable: false
         faxNumber:
           type: string
           description: The fax number of the user. Returned only on $select.
-          nullable: false
         givenName:
           type: string
           description: The given name (first name) of the user. Returned by default. Supports $filter.
-          nullable: false
         lastPasswordChangeDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           description: 'The time when this user last changed their password. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z Returned only on $select. Read-only.'
           format: date-time
-          nullable: false
           readOnly: true
         legalAgeGroupClassification:
           type: string
           description: 'Used by enterprise applications to determine the legal age group of the user. This property is read-only and calculated based on ageGroup and consentProvidedForMinor properties. Allowed values: null, minorWithOutParentalConsent, minorWithParentalConsent, minorNoParentalConsentRequired, notAdult and adult. Refer to the legal age group property definitions for further information. Returned only on $select.'
-          nullable: false
         mail:
           type: string
           description: 'The SMTP address for the user, for example, ''jeff@contoso.onowncloud.com''. Returned by default. Supports $filter and endsWith.'
-          nullable: false
         mailNickname:
           type: string
           description: The mail alias for the user. This property must be specified when a user is created. Returned only on $select. Supports $filter.
-          nullable: false
         mobilePhone:
           type: string
           description: The primary cellular telephone number for the user. Returned by default. Read-only for users synced from on-premises directory.
-          nullable: false
         onPremisesDistinguishedName:
           type: string
           description: Contains the on-premises Active Directory distinguished name or DN. The property is only populated for customers who are synchronizing their on-premises directory to Azure Active Directory via Azure AD Connect. Read-only. Returned only on $select.
-          nullable: true
         onPremisesDomainName:
           type: string
           description: 'Contains the on-premises domainFQDN, also called dnsDomainName synchronized from the on-premises directory. The property is only populated for customers who are synchronizing their on-premises directory to Azure Active Directory via Azure AD Connect. Read-only. Returned only on $select.'
-          nullable: true
         onPremisesImmutableId:
           type: string
           description: 'This property is used to associate an on-premises Active Directory user account to their Azure AD user object. This property must be specified when creating a new user account in the Graph if you are using a federated domain for the user''s userPrincipalName (UPN) property. NOTE: The $ and _ characters cannot be used when specifying this property. Returned only on $select. Supports $filter (eq, ne, not, ge, le, in)..'
-          nullable: true
         onPremisesSyncEnabled:
           type: boolean
           description: 'true if this object is synced from an on-premises directory; false if this object was originally synced from an on-premises directory but is no longer synced; null if this object has never been synced from an on-premises directory (default). Read-only. Returned only on $select. Supports $filter (eq, ne, not, in, and eq on null values).'
-          nullable: true
         onPremisesLastSyncDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           description: 'Indicates the last time at which the object was synced with the on-premises directory; for example: 2013-02-16T03:04:54Z. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only. Returned only on $select. Supports $filter (eq, ne, not, ge, le, in).'
           format: date-time
-          nullable: true
         onPremisesSamAccountName:
           type: string
           description: 'Contains the on-premises SAM account name synchronized from the on-premises directory. Read-only.'
-          nullable: true
         onPremisesUserPrincipalName:
           type: string
           description: 'Contains the on-premises userPrincipalName synchronized from the on-premises directory. The property is only populated for customers who are synchronizing their on-premises directory to Azure Active Directory via Azure AD Connect. Read-only. Returned only on $select. Supports $filter (eq, ne, not, ge, le, in, startsWith).'
-          nullable: true
         officeLocation:
           type: string
           description: The office location in the user's place of business. Returned by default.
-          nullable: false
         postalCode:
           type: string
           description: 'The postal code for the user''s postal address. The postal code is specific to the user''s country/region. In the United States of America, this attribute contains the ZIP code. Returned only on $select.'
-          nullable: false
         preferredLanguage:
           type: string
           description: The preferred language for the user. Should follow ISO 639-1 Code; for example 'en-US'. Returned by default.
-          nullable: false
           pattern: '^[a-z]{2}(-[A-Z]{2})?$'
           maxLength: 7
         state:
           type: string
           description: The state or province in the user's address. Returned only on $select. Supports $filter.
-          nullable: false
         streetAddress:
           type: string
           description: The street address of the user's place of business. Returned only on $select.
-          nullable: false
         surname:
           type: string
           description: The user's surname (family name or last name). Returned by default. Supports $filter.
-          nullable: false
         usageLocation:
           type: string
           description: 'A two letter country code (ISO standard 3166). Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries.  Examples include: ''US'', ''JP'', and ''GB''. Not nullable. Returned only on $select. Supports $filter.'
-          nullable: false
           maxLength: 3
         userPrincipalName:
           type: string
           description: 'The user principal name (UPN) of the user. The UPN is an Internet-style login name for the user based on the Internet standard RFC 822. By convention, this should map to the user''s email name. The general format is alias@domain, where domain must be present in the tenant''s collection of verified domains. This property is required when a user is created. The verified domains for the tenant can be accessed from the verifiedDomains property of organization. Returned by default. Supports $filter, $orderby, and endsWith.'
-          nullable: false
         userType:
           type: string
           description: 'A string value that can be used to classify user types in your directory, such as ''Member'' and ''Guest''. Returned only on $select. Supports $filter.'
-          nullable: false
         aboutMe:
           type: string
           description: A freeform text entry field for the user to describe themselves. Returned only on $select.
-          nullable: false
         birthday:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
@@ -1171,7 +1126,6 @@ components:
         preferredName:
           type: string
           description: The preferred name for the user. Returned only on $select.
-          nullable: true
         drive:
           $ref: '#/components/schemas/drive'
         drives:
@@ -1187,32 +1141,26 @@ components:
         driveId:
           type: string
           description: Unique identifier of the drive instance that contains the item. Read-only.
-          nullable: false
           readOnly: true
         driveType:
           type: string
           description: 'Identifies the type of drive. See [drive][] resource for values. Read-only.'
-          nullable: false
           readOnly: true
         id:
           type: string
           description: Unique identifier of the item in the drive. Read-only.
-          nullable: false
           readOnly: true
         name:
           type: string
           description: The name of the item being referenced. Read-only.
-          nullable: false
           readOnly: true
         path:
           type: string
           description: Path that can be used to navigate to the item. Read-only.
-          nullable: false
           readOnly: true
         shareId:
           type: string
           description: 'A unique identifier for a shared resource that can be accessed via the [Shares][] API.'
-          nullable: false
     driveItem:
       description: Reprensents a resource inside a drive. Read-only.
       readOnly: true
@@ -1237,16 +1185,13 @@ components:
         description:
           type: string
           description: Provides a user-visible description of the item. Optional.
-          nullable: false
         eTag:
           type: string
           description: ETag for the item. Read-only.
-          nullable: false
           readOnly: true
         lastModifiedBy:
           $ref: '#/components/schemas/identitySet'
           description: 'Identity of the user, device, and application which last modified the item. Read-only.'
-          nullable: false
           readOnly: true
         lastModifiedDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
@@ -1257,36 +1202,29 @@ components:
         name:
           type: string
           description: The name of the item. Read-write.
-          nullable: false
         parentReference:
           $ref: '#/components/schemas/itemReference'
           description: 'Parent information, if the item has a parent. Read-write.'
-          nullable: false
         webUrl:
           type: string
           description: URL that displays the resource in the browser. Read-only.
-          nullable: false
           readOnly: true
         createdByUser:
           $ref: '#/components/schemas/user'
           description: Identity of the user who created the item. Read-only.
-          nullable: false
           readOnly: true
         lastModifiedByUser:
           $ref: '#/components/schemas/user'
           description: Identity of the user who last modified the item. Read-only.
-          nullable: false
           readOnly: true
         # driveItem
         content:
           type: string
           description: 'The content stream, if the item represents a file.'
           format: base64url
-          nullable: false
         cTag:
           type: string
           description: An eTag for the content of the item. This eTag is not changed if only the metadata is changed. Note This property is not returned if the item is a folder. Read-only.
-          nullable: false
           readOnly: true
         deleted:
           $ref: '#/components/schemas/deleted'
@@ -1304,12 +1242,10 @@ components:
           type: integer
           description: Size of the item in bytes. Read-only.
           format: int64
-          nullable: false
           readOnly: true
         webDavUrl:
           type: string
           description: WebDAV compatible URL for the item. Read-only.
-          nullable: false
           readOnly: true
         children:
           type: array
@@ -1325,7 +1261,6 @@ components:
         state:
           type: string
           description: Represents the state of the deleted item.
-          nullable: false
     openGraphFile:
       type: object
       description: 'File metadata, if the item is a file. Read-only.'
@@ -1336,11 +1271,9 @@ components:
         mimeType:
           type: string
           description: The MIME type for the file. This is determined by logic on the server and might not be the value provided when the file was uploaded. Read-only.
-          nullable: false
           readOnly: true
         processingMetadata:
           type: boolean
-          nullable: false
     fileSystemInfo:
       type: object
       description: File system information on client. Read-write.
@@ -1350,19 +1283,16 @@ components:
           type: string
           description: The UTC date and time the file was created on a client.
           format: date-time
-          nullable: false
         lastAccessedDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           description: The UTC date and time the file was last accessed. Available for the recent file list only.
           format: date-time
-          nullable: false
         lastModifiedDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           description: The UTC date and time the file was last modified on a client.
           format: date-time
-          nullable: false
     folder:
       type: object
       description: 'Folder metadata, if the item is a folder. Read-only.'
@@ -1373,7 +1303,6 @@ components:
           type: integer
           description: Number of children contained immediately within this container.
           format: int32
-          nullable: false
         view:
           $ref: '#/components/schemas/folderView'
     image:
@@ -1386,14 +1315,12 @@ components:
           type: integer
           description: 'Optional. Height of the image, in pixels. Read-only.'
           format: int32
-          nullable: false
           readOnly: true
         width:
           maximum: 2147483647
           type: integer
           description: 'Optional. Width of the image, in pixels. Read-only.'
           format: int32
-          nullable: false
           readOnly: true
     root:
       type: object
@@ -1407,30 +1334,25 @@ components:
           type: integer
           description: 'Total space consumed by files in the recycle bin, in bytes. Read-only.'
           format: int64
-          nullable: false
           readOnly: true
         remaining:
           type: integer
           description: 'Total space remaining before reaching the quota limit, in bytes. Read-only.'
           format: int64
-          nullable: false
           readOnly: true
         state:
           type: string
           description: Enumeration value that indicates the state of the storage space. Read-only.
-          nullable: false
           readOnly: true
         total:
           type: integer
           description: 'Total allowed storage space, in bytes. Read-only.'
           format: int64
-          nullable: false
           readOnly: true
         used:
           type: integer
           description: 'Total space used, in bytes. Read-only.'
           format: int64
-          nullable: false
           readOnly: true
     hashes:
       type: object
@@ -1440,21 +1362,17 @@ components:
         crc32Hash:
           type: string
           description: The CRC32 value of the file (if available). Read-only.
-          nullable: false
           maxLength: 8
         quickXorHash:
           type: string
           description: A proprietary hash of the file that can be used to determine if the contents of the file have changed (if available). Read-only.
-          nullable: false
         sha1Hash:
           type: string
           description: SHA1 hash for the contents of the file (if available). Read-only.
-          nullable: false
           maxLength: 40
         sha256Hash:
           type: string
           description: SHA256 hash for the contents of the file (if available). Read-only.
-          nullable: false
           maxLength: 160
     folderView:
       type: object
@@ -1463,15 +1381,12 @@ components:
         sortBy:
           type: string
           description: The method by which the folder should be sorted.
-          nullable: false
         sortOrder:
           type: string
           description: 'If true, indicates that items should be sorted in descending order. Otherwise, items should be sorted ascending.'
-          nullable: false
         viewType:
           type: string
           description: The type of view that should be used to represent the folder.
-          nullable: false
     group:
       type: object
       title: group
@@ -1486,69 +1401,54 @@ components:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           format: date-time
-          nullable: false
         createdDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           description: 'Timestamp of when the group was created. The value cannot be modified and is automatically populated when the group is created. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Returned by default. Supports $filter (eq, ne, not, ge, le, in). Read-only.'
           format: date-time
-          nullable: true
         description:
           type: string
           description: 'An optional description for the group. Returned by default. Supports $filter (eq, ne, not, ge, le, startsWith) and $search.'
-          nullable: true
         displayName:
           type: string
           description: 'The display name for the group. This property is required when a group is created and cannot be cleared during updates. Returned by default. Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values), $search, and $orderBy.'
-          nullable: true
         expirationDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           description: 'Timestamp of when the group is set to expire. The value cannot be modified and is automatically populated when the group is created. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Returned by default. Supports $filter (eq, ne, not, ge, le, in). Read-only.'
           format: date-time
-          nullable: true
         mail:
           type: string
           description: 'The SMTP address for the group, for example, ''serviceadmins@owncloud.com''. Returned by default. Read-only. Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values).'
-          nullable: true
         onPremisesDomainName:
           type: string
           description: 'Contains the on-premises domain FQDN, also called dnsDomainName synchronized from the on-premises directory.'
-          nullable: true
         onPremisesLastSyncDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           description: 'Indicates the last time at which the group was synced with the on-premises directory.The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Returned by default. Read-only. Supports $filter (eq, ne, not, ge, le, in).'
           format: date-time
-          nullable: true
         onPremisesSamAccountName:
           type: string
           description: 'Contains the on-premises SAM account name synchronized from the on-premises directory. The property is only populated for customers who are synchronizing their on-premises directory to Azure Active Directory via Azure AD Connect.Returned by default. Supports $filter (eq, ne, not, ge, le, in, startsWith). Read-only.'
-          nullable: true
         onPremisesSyncEnabled:
           type: boolean
           description: 'true if this group is synced from an on-premises directory; false if this group was originally synced from an on-premises directory but is no longer synced; null if this object has never been synced from an on-premises directory (default). Returned by default. Read-only. Supports $filter (eq, ne, not, in, and eq on null values).'
-          nullable: true
         preferredLanguage:
           type: string
           description: 'The preferred language for a group. Should follow ISO 639-1 Code; for example en-US. Returned by default. Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values).'
-          nullable: true
         securityEnabled:
           type: boolean
           description: 'Specifies whether the group is a security group. Required. Returned by default. Supports $filter (eq, ne, not, in).'
-          nullable: true
         securityIdentifier:
           type: string
           description: 'Security identifier of the group, used in Windows scenarios. Returned by default.'
-          nullable: true
         visibility:
           type: string
           description: 'Specifies the group join policy and group content visibility for groups. Possible values are: Private, Public, or Hiddenmembership. It can''t be updated later. Other values of visibility can be updated after group creation. Groups assignable to roles are always Private. See group visibility options to learn more. Returned by default. Nullable.'
-          nullable: true
         createdOnBehalfOf:
           $ref: '#/components/schemas/directoryObject'
           description: 'The user (or application) that created the group. NOTE: This is not set if the user is an administrator. Read-only.'
-          nullable: true
         memberOf:
           type: array
           items:
@@ -1573,7 +1473,6 @@ components:
           description: The group's drives. Read-only.
         isArchived:
               type: boolean
-              nullable: true
     directoryObject:
       type: object
       properties:
@@ -1587,9 +1486,7 @@ components:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?([Zz]|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           format: date-time
-          nullable: false
       description: 'Represents a Directory object. Read-only.'
-      nullable: true
     odata.error:
       required:
         - error


### PR DESCRIPTION
# Description

- according to https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0 the `nullable` modifier will be removed
