### PR TITLE
Switch back to upstream openapi-generator

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -27,9 +27,7 @@ config = {
 			'branch': 'main',
 		},
 	},
-	# FIXME: switch back to openapitools/openapi-generator-cli
-	# when https://github.com/OpenAPITools/openapi-generator/pull/11490 is merged
-	'openapi-generator-image': 'owncloudci/openapi-generator'
+	'openapi-generator-image': 'openapitools/openapi-generator-cli:latest'
 }
 
 def main(ctx):

--- a/.drone.star
+++ b/.drone.star
@@ -27,7 +27,7 @@ config = {
 			'branch': 'main',
 		},
 	},
-	'openapi-generator-image': 'openapitools/openapi-generator-cli:latest'
+	'openapi-generator-image': 'openapitools/openapi-generator-cli:latest@sha256:2957b6c14449411b92512602ad0ecff75dc5f164abc1cbc80769de4e7b711d4c'
 }
 
 def main(ctx):

--- a/.drone.star
+++ b/.drone.star
@@ -22,7 +22,7 @@ config = {
 		},
 		'cpp-qt-client': {
 			'src': "out-cpp-qt-client",
-			'clean-src': "out-cpp-qt-client/client/*",
+			'clean-src': "out-cpp-qt-client/*",
 			'repo-slug': "libre-graph-api-cpp-qt-client",
 			'branch': 'main',
 		},
@@ -233,7 +233,7 @@ def validate(lang):
 				"name": "validate-cpp",
 				"image": "owncloudci/client",
 				"commands": [
-					"cd %s" % config["languages"][lang]["src"],
+					"cd %s/client" % config["languages"][lang]["src"],
 					"cmake -GNinja .",
 					"ninja -j1",
 				]


### PR DESCRIPTION
Unfortunately we still need to use latest, as the fix from our fork is merged upstream but not released yet.

TODO in follow up PR: Pin version.


FIXES: https://github.com/owncloud/libre-graph-api/issues/30