### PR TITLE
Bump version to v1.14.1

### DIFF
--- a/api/openapi-spec/v0.0.yaml
+++ b/api/openapi-spec/v0.0.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Libre Graph API
-  version: v0.14.0
+  version: v0.14.1
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
To trigger a release of the "sub-projects" after recreating the LICENSE
files.