### PR TITLE
Bump version to v1.14.2

### DIFF
--- a/api/openapi-spec/v0.0.yaml
+++ b/api/openapi-spec/v0.0.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Libre Graph API
-  version: v0.14.1
+  version: v0.14.2
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
LICENSE was still being	removed in target repos. Should be fixed with
latest change in .drone.star