### PR TITLE
Add bearer auth to edu requests

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -831,6 +831,8 @@ paths:
       tags:
         - educationUser
       summary: Get entities from education users
+      security:
+        - bearerAuth: []
       operationId: ListEducationUsers
       parameters:
         - name: $orderby
@@ -892,6 +894,8 @@ paths:
       tags:
         - educationUser
       summary: Add new education user
+      security:
+        - bearerAuth: []
       operationId: CreateEducationUser
       requestBody:
         description: New entity
@@ -920,6 +924,8 @@ paths:
       tags:
         - educationUser
       summary: Get properties of educationUser
+      security:
+        - bearerAuth: []
       operationId: GetEducationUser
       parameters:
         - name: user-id
@@ -961,6 +967,8 @@ paths:
       tags:
         - educationUser
       summary: Update properties of educationUser
+      security:
+        - bearerAuth: []
       operationId: UpdateEducationUser
       parameters:
         - name: user-id
@@ -1005,6 +1013,8 @@ paths:
       tags:
         - educationUser
       summary: Delete educationUser
+      security:
+        - bearerAuth: []
       operationId: DeleteEducationUser
       parameters:
         - name: user-id
@@ -1024,6 +1034,8 @@ paths:
       tags:
         - educationSchool
       summary: Get a list of schools and their properties
+      security:
+        - bearerAuth: []
       operationId: ListSchools
       responses:
         '200':
@@ -1051,6 +1063,8 @@ paths:
       tags:
         - educationSchool
       summary: Add new school
+      security:
+        - bearerAuth: []
       operationId: CreateSchool
       requestBody:
         description: New school
@@ -1079,6 +1093,8 @@ paths:
       tags:
         - educationSchool
       summary: Get the properties of a specific school
+      security:
+        - bearerAuth: []
       operationId: GetSchool
       parameters:
         - name: school-id
@@ -1104,6 +1120,8 @@ paths:
       tags:
         - educationSchool
       summary: Update properties of a school
+      security:
+        - bearerAuth: []
       operationId: UpdateSchool
       parameters:
         - name: school-id
@@ -1138,6 +1156,8 @@ paths:
       tags:
         - educationSchool
       summary: Delete school
+      security:
+        - bearerAuth: []
       operationId: DeleteSchool
       parameters:
         - name: school-id
@@ -1157,6 +1177,8 @@ paths:
       tags:
         - educationSchool
       summary: Assign a user to a school
+      security:
+        - bearerAuth: []
       operationId: AddUserToSchool
       parameters:
         - name: school-id
@@ -1188,6 +1210,8 @@ paths:
       tags:
         - educationSchool
       summary: Unassign user from a school
+      security:
+        - bearerAuth: []
       operationId: DeleteUserFromSchool
       parameters:
         - name: school-id
@@ -1214,6 +1238,8 @@ paths:
       tags:
         - educationSchool
       summary: Assign a class to a school
+      security:
+        - bearerAuth: []
       operationId: AddClassToSchool
       parameters:
         - name: school-id
@@ -1245,6 +1271,8 @@ paths:
       tags:
         - educationSchool
       summary: Unassign class from a school
+      security:
+        - bearerAuth: []
       operationId: DeleteClassFromSchool
       parameters:
         - name: school-id
@@ -1272,6 +1300,8 @@ paths:
         - educationClass
       summary: list education classes
       operationId: ListClasses
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: Retrieved entities
@@ -1300,6 +1330,8 @@ paths:
       tags:
         - educationClass
       summary: Add new education class
+      security:
+        - bearerAuth: []
       operationId: CreateClass
       requestBody:
         description: New entity
@@ -1311,7 +1343,6 @@ paths:
               class:
                 $ref: '#/components/examples/educationClass_post'
         required: true
-
       responses:
         '201':
           description: Created entity
@@ -1329,6 +1360,8 @@ paths:
       tags:
         - educationClass
       summary: Get class by key
+      security:
+        - bearerAuth: []
       operationId: GetClass
       parameters:
         - name: class-id
@@ -1354,6 +1387,8 @@ paths:
       tags:
         - educationClass
       summary: Update properties of a education class
+      security:
+        - bearerAuth: []
       operationId: UpdateClass
       parameters:
         - name: class-id
@@ -1393,6 +1428,8 @@ paths:
       tags:
         - educationClass
       summary: Delete education class
+      security:
+        - bearerAuth: []
       operationId: DeleteClass
       parameters:
         - name: class-id
@@ -1412,6 +1449,8 @@ paths:
       tags:
         - educationClass
       summary: Assign a user to a class
+      security:
+        - bearerAuth: []
       operationId: AddUserToClass
       parameters:
         - name: class-id
@@ -1443,6 +1482,8 @@ paths:
       tags:
         - educationClass
       summary: Unassign user from a class
+      security:
+        - bearerAuth: []
       operationId: DeleteUserFromClass
       parameters:
         - name: class-id
@@ -2383,6 +2424,10 @@ components:
       openId:
         type: openIdConnect
         openIdConnectUrl: https://ocis.ocis-traefik.latest.owncloud.works/.well-known/openid-configuration
+      bearerAuth:
+        type: http
+        scheme: bearer
+        bearerFormat: plain
   examples:
     tags_put:
       value:


### PR DESCRIPTION
# Description

Add bearer auth to education requests.

## Consequences

- OpenIDConnect stays the "global" auth mechanism
- Bearer Auth is possible only on the marked requests