### PR TITLE
fix /applications endpoint

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -1657,7 +1657,7 @@ paths:
           description: No content
         default:
           $ref: '#/components/responses/error'
-  /application/{application-id}:
+  /applications/{application-id}:
     get:
       description: 'Get properties of an application by id'
       parameters:


### PR DESCRIPTION
graph always uses the plural form