### PR TITLE
Bump openapi-generator to v6.2.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -24,7 +24,7 @@ config = {
 			'branch': 'main',
 		},
 	},
-	'openapi-generator-image': 'openapitools/openapi-generator-cli:latest@sha256:2957b6c14449411b92512602ad0ecff75dc5f164abc1cbc80769de4e7b711d4c'
+	'openapi-generator-image': 'openapitools/openapi-generator-cli:v6.2.0@sha256:e6153ebc2f1a54985a50c53942e40285f1fbe64f1c701317da290bfff4abe303'
 }
 
 def main(ctx):


### PR DESCRIPTION
We now pin the image to the SHA for the 6.2.0 release. To get away from the pre-release snapshot we've been using for a while now.

Closes: #38

As far as I could see this doesn't introduce any problematic changes to the libraries that we are generating from this. 