### PR TITLE
Remove redundant and unused 'createdByUser' and 'lastModifiedByUser'

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -1883,14 +1883,6 @@ components:
           type: string
           description: URL that displays the resource in the browser. Read-only.
           readOnly: true
-        createdByUser:
-          $ref: '#/components/schemas/user'
-          description: Identity of the user who created the item. Read-only.
-          readOnly: true
-        lastModifiedByUser:
-          $ref: '#/components/schemas/user'
-          description: Identity of the user who last modified the item. Read-only.
-          readOnly: true
         # drive
         driveType:
           type: string
@@ -2089,14 +2081,6 @@ components:
         webUrl:
           type: string
           description: URL that displays the resource in the browser. Read-only.
-          readOnly: true
-        createdByUser:
-          $ref: '#/components/schemas/user'
-          description: Identity of the user who created the item. Read-only.
-          readOnly: true
-        lastModifiedByUser:
-          $ref: '#/components/schemas/user'
-          description: Identity of the user who last modified the item. Read-only.
           readOnly: true
         # driveItem
         content:


### PR DESCRIPTION
Not sure how that ended up in our spec but we're not using them currently and the graph api mandates createdBy and lastModifiedBy instead.

Closes: #25