### PR TITLE
Remove unused attributes from groups and educationClass

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -332,8 +332,6 @@ paths:
                 - displayName
                 - mail
                 - members
-                - onPremisesDomainName
-                - onPremisesSamAccountName
               type: string
         - name: $expand
           in: query
@@ -418,8 +416,6 @@ paths:
                 - description
                 - displayName
                 - members
-                - onPremisesDomainName
-                - onPremisesSamAccountName
               type: string
         - name: $expand
           in: query
@@ -1759,12 +1755,6 @@ components:
           items:
             $ref: '#/components/schemas/user'
           description: 'Users and groups that are members of this group. HTTP Methods: GET (supported for all groups), Nullable. Supports $expand.'
-        onPremisesDomainName:
-          type: string
-          description: 'Contains the on-premises domainFQDN, also called dnsDomainName synchronized from the on-premises directory. The property is only populated for customers who are synchronizing their on-premises directory to Azure Active Directory via Azure AD Connect. Read-only. Returned only on $select.'
-        onPremisesSamAccountName:
-          type: string
-          description: 'Contains the on-premises SAM account name synchronized from the on-premises directory. Read-only.'
         'members@odata.bind':
           type: array
           items:
@@ -2379,12 +2369,6 @@ components:
           items:
             $ref: '#/components/schemas/user'
           description: 'Users and groups that are members of this group. HTTP Methods: GET (supported for all groups), Nullable. Supports $expand.'
-        onPremisesDomainName:
-          type: string
-          description: 'Contains the on-premises domainFQDN, also called dnsDomainName synchronized from the on-premises directory. The property is only populated for customers who are synchronizing their on-premises directory to Azure Active Directory via Azure AD Connect. Read-only. Returned only on $select.'
-        onPremisesSamAccountName:
-          type: string
-          description: 'Contains the on-premises SAM account name synchronized from the on-premises directory. Read-only.'
         'members@odata.bind':
           type: array
           items:


### PR DESCRIPTION
We currently don't use onPremisesDomainName and onPremisesSamAccountName anywhere.

Closes: #71