### PR TITLE
Add "groupTypes" property to the group resource

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -2654,6 +2654,11 @@ components:
         displayName:
           type: string
           description: 'The display name for the group. This property is required when a group is created and cannot be cleared during updates. Returned by default. Supports $search and $orderBy.'
+        groupTypes:
+          description: 'Specifies the group types. In MS Graph a group can have multiple types, so this is an array. In libreGraph the possible group types deviate from the MS Graph. The only group type that we currently support is "ReadOnly", which is set for groups that cannot be modified on the current instance.'
+          type: array
+          items:
+            type: string
         members:
           type: array
           items:


### PR DESCRIPTION
We'll be using this to indicate groups as being "ReadOnly". That is groups, coming from some external system which we can't update.