### PR TITLE
Qt6 support

### DIFF
--- a/templates/cpp-qt-client/CMakeLists.txt.mustache
+++ b/templates/cpp-qt-client/CMakeLists.txt.mustache
@@ -82,5 +82,30 @@ set(HEADER
     {{prefix}}Object.h
 )
 install(FILES ${HEADER} DESTINATION include/OpenAPI/${TARGET_NAME})
-install(TARGETS client EXPORT ${TARGET_NAME}Config RUNTIME DESTINATION bin LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(EXPORT ${TARGET_NAME}Config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${TARGET_NAME} NAMESPACE OpenAPI::)
+
+include(CMakePackageConfigHelpers)
+
+# openapi-generator-cli doesn't allow us to add extra files and the
+# Config.cmake it ships is not usable...
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/Config.cmake.in"
+"@PACKAGE_INIT@
+include(CMakeFindDependencyMacro)
+find_dependency(Qt5Core)
+
+include(\"\${CMAKE_CURRENT_LIST_DIR}/@TARGET_NAME@Targets.cmake\")"
+)
+
+configure_package_config_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/Config.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}Config.cmake"
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${TARGET_NAME}
+)
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}ConfigVersion.cmake"
+  VERSION ${APP_VERSION}
+  COMPATIBILITY SameMajorVersion )
+
+install(TARGETS client EXPORT ${TARGET_NAME}Targets RUNTIME DESTINATION bin LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(EXPORT ${TARGET_NAME}Targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${TARGET_NAME} NAMESPACE OpenAPI::)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}Config.cmake" "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}ConfigVersion.cmake"  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${TARGET_NAME})

--- a/templates/cpp-qt-client/CMakeLists.txt.mustache
+++ b/templates/cpp-qt-client/CMakeLists.txt.mustache
@@ -20,10 +20,10 @@ if (WIN32)
     set(BUILD_SHARED_LIBS OFF)
 endif ()
 
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Network REQUIRED){{#authMethods}}{{#isOAuth}}
-find_package(Qt5Gui REQUIRED){{/isOAuth}}{{/authMethods}}{{#contentCompression}}
-find_package(ZLIB REQUIRED){{/contentCompression}}
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Network REQUIRED)
+
+find_package(ZLIB REQUIRED)
 
 add_library(client
 {{#models}}
@@ -50,7 +50,7 @@ target_include_directories(client PUBLIC
 
 add_library(OpenAPI::${TARGET_NAME} ALIAS client)
 
-target_link_libraries(client PRIVATE Qt5::Core Qt5::Network{{#authMethods}}{{#isOAuth}} Qt5::Gui{{/isOAuth}}{{/authMethods}}{{#contentCompression}} ${ZLIB_LIBRARIES}{{/contentCompression}})
+target_link_libraries(client PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network Qt${QT_VERSION_MAJOR}::Gui ZLIB::ZLIB)
 
 set_target_properties(client PROPERTIES
                 CXX_STANDARD 14
@@ -90,7 +90,9 @@ include(CMakePackageConfigHelpers)
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/Config.cmake.in"
 "@PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
-find_dependency(Qt5Core)
+find_dependency(Qt${QT_VERSION_MAJOR}Core)
+find_dependency(Qt${QT_VERSION_MAJOR}Gui)
+find_dependency(Qt${QT_VERSION_MAJOR}Network)
 
 include(\"\${CMAKE_CURRENT_LIST_DIR}/@TARGET_NAME@Targets.cmake\")"
 )


### PR DESCRIPTION
Depends on https://github.com/owncloud/libre-graph-api/pull/103

@dragotin this will prefer Qt6, from your perspective as a packager, should I add an option to force Qt6 and assume 5 otherwise?