### PR TITLE
[WIP] add Sharing NG endpoints

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -3094,19 +3094,23 @@ components:
     sharePointIdentitySet:
       type: object
       description: This resource is used to represent a set of identities associated with various events for an item, such as created by or last modified by.
-      properties:     
-        #application:
-        #  $ref: '#/components/schemas/identity'
-        #  description: Optional. The application associated with this action.
-        #device:
-        #  $ref: '#/components/schemas/identity'
-        #  description: Optional. The device associated with this action.
+      properties:
         user:
           $ref: '#/components/schemas/identity'
           description: Optional. The user associated with this action.
         group:
           $ref: '#/components/schemas/identity'
           description: Optional. The group associated with this action.
+
+        # unused  
+        #application:
+        #  $ref: '#/components/schemas/identity'
+        #  description: Optional. The application associated with this action.
+
+        # unused
+        #device:
+        #  $ref: '#/components/schemas/identity'
+        #  description: Optional. The device associated with this action.
         # other properties omitted for now
     identity:
       type: object
@@ -3161,12 +3165,18 @@ components:
         '@libre.graph.displayName':
           type: string
           description: Provides a user-visible display name of the link. Optional. Libregraph only.
+
+        # unused
         #webHtml:
         #  type: string
         #  description: For `embed` links, this property contains the HTML code for an `<iframe>` element that will embed the item in a webpage.
+
+        # unused
         #application:
         #  description: The app the link is associated with.
         #  $ref: '#/components/schemas/identity'
+
+        # unused
         #scope:
         #  type: string
         #  enum: [anonymous, organization, existingAccess, users]
@@ -3393,24 +3403,24 @@ components:
         displayName:
           type: string
           description: Provides a user-visible display name of the link. Optional. Libregraph only.
-        # to invite guests or specify which users should be sent the link we could add this
+        # unused. we could add thisto invite guests or specify which users should be sent the link
         #recipients:
         #  type: array
         #  items:
         #    $ref: '#/components/schemas/driveRecipient'
         #  description: A collection of recipients who will receive access and the sharing link.
 
-        # can be added later
+        # unused. can be added later
         #scope:
         #  type: string
         #  description: Optional. The scope of link to create. Either `anonymous`, `organization`, or `users`.
 
-        # In ocis recipients configure if they want to be notified
+        # unused. In ocis recipients configure if they want to be notified
         #sendNotification:
         #  type: boolean
         #  description: Optional. If `true`, this method sends a sharing link in an email to users specified in recipients. The default value is `false`. Optional.
 
-        # not supported by ocis
+        # unused. not supported by ocis
         #retainInheritedPermissions:
         #  type: boolean
         #  description: Optional. If `true` (default), any existing inherited permissions are retained on the shared item when sharing this item for the first time. If `false`, all existing permissions are removed when sharing for the first time.
@@ -3579,7 +3589,7 @@ components:
           description: "The drive alias can be used in clients to make the urls user friendly. Example: 'personal/einstein'. This will be used to resolve to the correct driveID."
         #driveType:
         # wie kommt man zum drive? web möchte im ui den pfad anzeigen, der wird aus dem driveAlias gebaut, aber die brauchen auch den driveType um das datenmodell konsistent zu haben
-        # momentan machen sie einen ocs list shares request und sichen sich dann den mountpoint anhand der id raus, aber cern möchte IMMER den personal space dazu sehen, incl pfad
+        # momentan machen sie einen ocs list shares request und sichen sich dann den mountpoint anhand der id raus, aber einige möchten IMMER den personal space dazu sehen, incl pfad
         path:
           type: string
           description: "The relative path of the item in relation to its drive root."

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -282,32 +282,21 @@ paths:
       summary: Create a sharing link for a DriveItem
       operationId: CreateLink
       description: |
-        You can use createLink action to share a driveItem via a sharing link.
+        You can use the createLink action to share a driveItem via a sharing link.
 
-        The **createLink** action will create a new sharing link if the specified link type doesn't already exist
-        for the calling application. If a sharing link of the specified type already exists for the app, the
-        existing sharing link will be returned.
+        The response will be a permission object with the link facet containing the created link details.
 
-        DriveItem resources inherit sharing permissions from their ancestors.
-      
         ## Link types
 
         For now, The following values are allowed for the type parameter.
         
-        | Type value      | Description                                                                                                                                                                                                           |
-        | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-        | view            | Creates a read-only link to the driveItem.                                                                                                                                                                            |
-        | edit            | Creates an read-write link to the driveItem.                                                                                                                                                                          |
-        | blocksDownload  | Creates a read-only link that blocks download to the driveItem.                                                                                                                                                       |
-        | createOnly      | Creates an upload-only link to the driveItem.                                                                                                                                                                         |
-
-        More built in types might be added with a speaking value but clients **MUST** treat the value as an
-        opaque identifier as custom types will be using UUIDs.
-
-      #  | embed           | Creates an embeddable link to the driveItem.                                                                                                                                                                          |
-      #  | review          | Creates a review link to the driveItem.                                                                                                                                                                               |
-      #  | addressBar      | Creates the default link that is shown in the browser address bars for newly created files. The organization admin configures whether this link type is supported, and what features are supported by this link type. |
-      #  | adminDefault    | Creates the default link to the driveItem as determined by the administrator of the organization. The policy is enforced for the organization by the admin                                                            |
+        | Value          | Display name      | Description                                                     |
+        | -------------- | ----------------- | --------------------------------------------------------------- |
+        | view           | View              | Creates a read-only link to the driveItem.                      |
+        | upload         | Upload            | Creates a read-write link to the folder driveItem.              |
+        | edit           | Edit              | Creates a read-write link to the driveItem.                     |
+        | createOnly     | File Drop         | Creates an upload-only link to the folder driveItem.            |
+        | blocksDownload | Secure View       | Creates a read-only link that blocks download to the driveItem. |
 
       parameters:
         - name: drive-id
@@ -329,44 +318,15 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                type:
-                  type: string
-                  description: Optional. The type of sharing link to create.
-                expirationDateTime:
-                  type: string
-                  description: Optional. A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission.
-                  format: date-time
-                password: 
-                  type: string
-                  description: Optional.The password of the sharing link that is set by the creator.
-
-                # to invite guests or specify which users should be sent the link we could add this
-                #recipients:
-                #  type: array
-                #  items:
-                #    $ref: '#/components/schemas/driveRecipient'
-                #  description: A collection of recipients who will receive access and the sharing link.
-
-                # can be added later
-                #scope:
-                #  type: string
-                #  description: Optional. The scope of link to create. Either `anonymous`, `organization`, or `users`.
-
-                # In ocis recipients configure if they want to be notified
-                #sendNotification:
-                #  type: boolean
-                #  description: Optional. If `true`, this method sends a sharing link in an email to users specified in recipients. The default value is `false`. Optional.
-
-                # not supported by ocis
-                #retainInheritedPermissions:
-                #  type: boolean
-                #  description: Optional. If `true` (default), any existing inherited permissions are retained on the shared item when sharing this item for the first time. If `false`, all existing permissions are removed when sharing for the first time.
+              $ref: '#/components/schemas/driveItemCreateLink'
             examples:
                 create viewer link:
                   value:
                     type: "view"
+                create editor link with custom display name:
+                  value:
+                    type: "edit"
+                    displayName: "Homework"
                 create editor link with expiry:
                   value:
                     type: "edit"
@@ -379,19 +339,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/permission'
               examples:
-                send viewer invite:
+                create viewer link:
                   value:
                     - id: "7181275c-557e-4adf-8e44-abdcf5389b6a"
                       link:
                         type: "view"
                         webUrl: "https://cloud.example.org/s/YlaySZdHCRHUDeE"
-                send editor invite with expiry:
+                create editor link with custom display name:
+                  value:
+                    - id: "7181275c-557e-4adf-8e44-abdcf5389b6a"
+                      link:
+                        type: "edit"
+                        displayName: "Homework"
+                        webUrl: "https://cloud.example.org/s/fdleMyGeerkIZTJ"
+                create editor link with expiry:
                   value:
                     - id: "a373c812-d786-42ae-a65f-ed87ee4abd49"
                       link:
                         type: "edit"
                         webUrl: "https://cloud.example.org/s/MlnTDkhcBlihNzO"
         '207':
+        # FIXME describe partial success response
           description: Partial success response TODO
         default:
           $ref: '#/components/responses/error'
@@ -406,6 +374,8 @@ paths:
       description: |
         Sends a sharing invitation for a `driveItem`. A sharing invitation provides permissions to the
         recipients and optionally sends them an email with a sharing link.
+
+        The response will be a permission object with the grantedToV2 property containing the created grant details.
 
         ## Roles property values
         For now, roles are only identified by a uuid. There are no hardcoded aliases like `read` or `write` because role actions can be completely customized.
@@ -467,7 +437,7 @@ paths:
                   description: "Sharing with a groups requires setting the @libre.graph.recipient.type annotation."
                   value:
                     recipients:
-                    - "@libre.graph.recipient.type": group
+                    - '@libre.graph.recipient.type': group
                       objectId: "167cbee2-0518-455a-bfb2-031fe0621e5d"
                     roles: [ "dfa16e02-3d88-45d8-8894-5b33a7df637" ]
                 send invite to user granting custom actions:
@@ -475,7 +445,7 @@ paths:
                   value:
                     recipients:
                     - objectId: "4c510ada-c86b-4815-8820-42cdf82c3d51"
-                    actions: [ "libre.graph/driveItem/basic/read", "libre.graph/driveItem/path/update" ]
+                    '@libre.graph.permissions.actions': [ "libre.graph/driveItem/basic/read", "libre.graph/driveItem/path/update" ]
       responses:
         '200':
           description: Response
@@ -487,15 +457,7 @@ paths:
                 send viewer invite:
                   value:
                     - id: "34646ab6-be32-43c9-89e6-987e0c237e9b"
-                      roles: [ "read" ]
-                      grantedToV2:
-                        - user:
-                            id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
-                            displayName: "Albert Einstein"
-                send editor invite with expiry:
-                  value:
-                    - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
-                      roles: [ "write" ]
+                      roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
                       grantedToV2:
                         - user:
                             id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
@@ -504,26 +466,44 @@ paths:
                   description: multiple permissions are returned as each has received a dedicated sharing id
                   value:
                     - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
-                      roles: [ "write" ]
+                      roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
                       grantedToV2:
                         - user:
                             id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
                             displayName: "Albert Einstein"
                     - id: "b470677e-a7f5-4304-8ef5-f5056a21fff1"
-                      roles: [ "write" ]
+                      roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
                       grantedToV2:
                         - user:
                             id: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"
                             displayName: "Marie Skłodowska Curie"
+                send editor invite with expiry:
+                  value:
+                    - id: "453b02be-4ec2-4e7d-b576-09fc153de812"
+                      roles: [ "a1c6f73e-482e-4078-a629-bbecb205abb" ]
+                      grantedToV2:
+                        - user:
+                            id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                            displayName: "Albert Einstein"
+                      expirationDateTime: "2018-07-15T14:00:00.000Z"
                 send manager invite to group:
                   value:
-                    - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
-                      roles: [ "owner" ]
+                    - id: "86765c0d-3905-444a-9b07-76201f8cf7df"
+                      roles: [ "dfa16e02-3d88-45d8-8894-5b33a7df637" ]
                       grantedToV2:
                         - group:
                             id: "167cbee2-0518-455a-bfb2-031fe0621e5d"
                             displayName: "Philosophy Haters"
+                send invite to user granting custom actions:
+                  value:
+                    - id: "c42b5cbd-2d65-42cf-b0b6-fb6d2b762256"
+                      grantedToV2:
+                        - user:
+                            id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                            displayName: "Albert Einstein"
+                      '@libre.graph.permissions.actions': [ "libre.graph/driveItem/basic/read", "libre.graph/driveItem/path/update" ]
         '207':
+        # FIXME describe partial success response
           description: Partial success response TODO
         '400':
           description: Bad request
@@ -558,7 +538,25 @@ paths:
 
         * For the owner of the item, all sharing permissions will be returned. This includes co-owners.
         * For a non-owner caller, only the sharing permissions that apply to the caller are returned.
-        * Sharing permission properties that contain secrets (e.g. `shareId` and `webUrl`) are only returned for callers that are able to create the sharing permission.
+        * Sharing permission properties that contain secrets (e.g. `webUrl`) are only returned for callers that are able to create the sharing permission.
+
+        All permission objects have an `id`. A permission representing
+        * a link has the `link` facet filled with details. 
+        * a share has the `roles` property set and the `grantedToV2` property filled with the grant recipient details.
+
+      # TODO hm, the ms graph api seems to always fill the `roles` property to indicate the actions granted by the link.
+      # | Value          | Display name      | Description                                                     | role?          |
+      # | -------------- | ----------------- | --------------------------------------------------------------- | -------------- |
+      # | view           | View              | Creates a read-only link to the driveItem.                      | viewer         |
+      # | upload         | Upload            | Creates a read-write link to the folder driveItem.              | uploader       |
+      # | edit           | Edit              | Creates a read-write link to the driveItem.                     | editor         |
+      # | createOnly     | File Drop         | Creates an upload-only link to the folder driveItem.            | createOnly     |
+      # | blocksDownload | Secure View       | Creates a read-only link that blocks download to the driveItem. | blocksDownload |
+      # AFAICT we wcill have to define the actions granted by a link type when we start to implement this
+      # but e.g. a createOnly role and blocksDownload should not show up in the drop down for sharing files internally ... 
+      # when we need to hardcode this anyway ... we should indicate that by using the buildIn flag ... but how do we prevent some roles from showing up in the internal sharing dialog ...
+      # for now leave out the roles property and hardcode the actions allowed by the link type
+
       parameters:
         - name: drive-id
           in: path
@@ -672,25 +670,47 @@ paths:
 
                 value:
                   - id: "67445fde-a647-4dd4-b015-fc5dafd2821d"
-                    roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
                     link:
                       type: "view"
                       webUrl: "https://cloud.example.org/s/fhGBMIkKFEHWysj"
-                  - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
-                    roles: [ "a1c6f73e-482e-4078-a629-bbecb205abb" ]
-                    expirationDateTime: "2018-07-15T14:00:00.000Z"
+
+                  - id: "34646ab6-be32-43c9-89e6-987e0c237e9b"
+                    roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
                     grantedToV2:
                       - user:
                           id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
                           displayName: "Albert Einstein"
-                    link:
-                      webUrl: "https://cloud.example.org/s/kXJpiJmMnQxVlaT"
-                  - id: "dda0bb77-ffe7-4867-a2bf-28af65b46aa3"
-                    actions: [ "libre.graph/driveItem/basic/read", "libre.graph/driveItem/path/update" ]
+                  - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
+                    roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
                     grantedToV2:
                       - user:
-                          id: "058bff95-6708-4fe5-91e4-9ea3d377588b"
-                          displayName: "Maurice Moss"
+                          id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                          displayName: "Albert Einstein"
+                  - id: "b470677e-a7f5-4304-8ef5-f5056a21fff1"
+                    roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
+                    grantedToV2:
+                      - user:
+                          id: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"
+                          displayName: "Marie Skłodowska Curie"
+                  - id: "453b02be-4ec2-4e7d-b576-09fc153de812"
+                    roles: [ "a1c6f73e-482e-4078-a629-bbecb205abb" ]
+                    grantedToV2:
+                      - user:
+                          id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                          displayName: "Albert Einstein"
+                    expirationDateTime: "2018-07-15T14:00:00.000Z"
+                  - id: "86765c0d-3905-444a-9b07-76201f8cf7df"
+                    roles: [ "dfa16e02-3d88-45d8-8894-5b33a7df637" ]
+                    grantedToV2:
+                      - group:
+                          id: "167cbee2-0518-455a-bfb2-031fe0621e5d"
+                          displayName: "Philosophy Haters"
+                  - id: "c42b5cbd-2d65-42cf-b0b6-fb6d2b762256"
+                    grantedToV2:
+                      - user:
+                          id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                          displayName: "Albert Einstein"
+                    '@libre.graph.permissions.actions': [ "libre.graph/driveItem/basic/read", "libre.graph/driveItem/path/update" ]
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -3121,22 +3141,6 @@ components:
           type: string
           writeOnly: true
           description: The user's password
-    sharingInvitation:
-      description: The `SharingInvitation` resource groups invitation-related data items into a single structure.
-      type: object
-      properties:
-        email:
-          type: string
-          description: The email address provided for the recipient of the sharing invitation.
-          readOnly: true
-        invitedBy:
-          $ref: '#/components/schemas/identitySet'
-          description: Provides information about who sent the invitation that created this permission, if that information is available.
-          readOnly: true
-        signInRequired:
-          type: boolean
-          description: If `true` the recipient of the invitation needs to sign in in order to access the shared item.
-          readOnly: true
     sharingLink:
       description: |
         The `SharingLink` resource groups link-related data items into a single structure.
@@ -3144,47 +3148,36 @@ components:
         If a `permission` resource has a non-null `sharingLink` facet, the permission represents a sharing link (as opposed to permissions granted to a person or group).
       type: object
       properties:
-        application:
-          $ref: '#/components/schemas/identity'
-          description: The app the link is associated with.
         type:
-          type: string
-          enum: [view, edit, blocksDownload, createOnly]
-          description: |
-            The type of the link created.
-
-            | Value          | Description                                                                                                                                                                                                           |
-            | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-            | view           | Creates a read-only link to the driveItem.                                                                                                                                                                            |
-            | edit           | Creates an read-write link to the driveItem.                                                                                                                                                                          |
-            | blocksDownload | Creates a read-only link that blocks download to the driveItem.                                                                                                                                                       |
-            | createOnly     | Creates an upload-only link to the driveItem.                                                                                                                                                                         |
-          # there are more link types available in https://learn.microsoft.com/en-us/graph/api/driveitem-createlink?view=graph-rest-beta&tabs=http#link-types
-          #  | review         | Creates a review link to the driveItem.                                                                                                                                                                               |
-          #  | embed          | Creates an embeddable link to the driveItem.                                                                                                                                                                          |
-          #  | addressBar     | Creates the default link that is shown in the browser address bars for newly created files. The organization admin configures whether this link type is supported, and what features are supported by this link type. |
-          #  | adminDefault   | Creates the default link to the driveItem as determined by the administrator of the organization. The policy is enforced for the organization by the admin                                                            |            
-        scope:
-          type: string
-          enum: [anonymous, organization, existingAccess, users]
-          description: |
-            The scope of the link represented by this permission. Value `anonymous` indicates the link is usable by anyone, `organization` indicates the link is only usable for users signed into the same tenant.
-
-            | Value          | Description                                                                                                           |
-            | -------------- | --------------------------------------------------------------------------------------------------------------------- |
-            | anonymous      | Anyone with the link has access, without needing to sign in. This may include people outside of your organization.    |
-            | organization   | Anyone signed into your organization (tenant) can use the link to get access.                                         |
-            | existingAccess | Only people who have already been granted access to the item through other means can access the item using this link. |
-            | users          | The link grants access only to a specific list of people.                                                             |
+          $ref: '#/components/schemas/sharingLinkType'
         preventsDownload:
           type: boolean
           description: If `true` then the user can only use this link to view the item on the web, and cannot use it to download the contents of the item.
-        webHtml:
-          type: string
-          description: For `embed` links, this property contains the HTML code for an `<iframe>` element that will embed the item in a webpage.
+          readOnly: true
         webUrl:
           type: string
           description: A URL that opens the item in the browser on the website.
+          readOnly: true
+        '@libre.graph.displayName':
+          type: string
+          description: Provides a user-visible display name of the link. Optional. Libregraph only.
+        #webHtml:
+        #  type: string
+        #  description: For `embed` links, this property contains the HTML code for an `<iframe>` element that will embed the item in a webpage.
+        #application:
+        #  description: The app the link is associated with.
+        #  $ref: '#/components/schemas/identity'
+        #scope:
+        #  type: string
+        #  enum: [anonymous, organization, existingAccess, users]
+        #  description: |
+        #    The scope of the link represented by this permission. Value `anonymous` indicates the link is usable by anyone, `organization` indicates the link is only usable for users signed into the same tenant.
+        #    | Value          | Description                                                                                                           |
+        #    | -------------- | --------------------------------------------------------------------------------------------------------------------- |
+        #    | anonymous      | Anyone with the link has access, without needing to sign in. This may include people outside of your organization.    |
+        #    | organization   | Anyone signed into your organization (tenant) can use the link to get access.                                         |
+        #    | existingAccess | Only people who have already been granted access to the item through other means can access the item using this link. |
+        #    | users          | The link grants access only to a specific list of people.                                                             |
     user:
       description: Represents an Active Directory user object.
       type: object
@@ -3366,6 +3359,60 @@ components:
             $ref: '#/components/schemas/permission'
           description: The set of permissions for the item. Read-only. Nullable.
           readOnly: true
+    sharingLinkType:      
+        type: string
+        enum: [view, upload, edit, createOnly, blocksDownload]
+        description: |
+          The type of the link created.
+
+          | Value          | Display name      | Description                                                     |
+          | -------------- | ----------------- | --------------------------------------------------------------- |
+          | view           | View              | Creates a read-only link to the driveItem.                      |
+          | upload         | Upload            | Creates a read-write link to the folder driveItem.              |
+          | edit           | Edit              | Creates a read-write link to the driveItem.                     |
+          | createOnly     | File Drop         | Creates an upload-only link to the folder driveItem.            |
+          | blocksDownload | Secure View       | Creates a read-only link that blocks download to the driveItem. |
+        # there are more link types available in https://learn.microsoft.com/en-us/graph/api/driveitem-createlink?view=graph-rest-beta&tabs=http#link-types
+        #  | review         | Creates a review link to the driveItem.                                                                                                                                                                               |
+        #  | embed          | Creates an embeddable link to the driveItem.                                                                                                                                                                          |
+        #  | addressBar     | Creates the default link that is shown in the browser address bars for newly created files. The organization admin configures whether this link type is supported, and what features are supported by this link type. |
+        #  | adminDefault   | Creates the default link to the driveItem as determined by the administrator of the organization. The policy is enforced for the organization by the admin                                                            |
+    driveItemCreateLink:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/sharingLinkType'
+        expirationDateTime:
+          type: string
+          description: Optional. A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission.
+          format: date-time
+        password: 
+          type: string
+          description: Optional.The password of the sharing link that is set by the creator.
+        displayName:
+          type: string
+          description: Provides a user-visible display name of the link. Optional. Libregraph only.
+        # to invite guests or specify which users should be sent the link we could add this
+        #recipients:
+        #  type: array
+        #  items:
+        #    $ref: '#/components/schemas/driveRecipient'
+        #  description: A collection of recipients who will receive access and the sharing link.
+
+        # can be added later
+        #scope:
+        #  type: string
+        #  description: Optional. The scope of link to create. Either `anonymous`, `organization`, or `users`.
+
+        # In ocis recipients configure if they want to be notified
+        #sendNotification:
+        #  type: boolean
+        #  description: Optional. If `true`, this method sends a sharing link in an email to users specified in recipients. The default value is `false`. Optional.
+
+        # not supported by ocis
+        #retainInheritedPermissions:
+        #  type: boolean
+        #  description: Optional. If `true` (default), any existing inherited permissions are retained on the shared item when sharing this item for the first time. If `false`, all existing permissions are removed when sharing for the first time.
     driveItemInvite:
       type: object
       properties:
@@ -3379,7 +3426,7 @@ components:
           items:
             type: string
           description: Specifies the roles that are to be granted to the recipients of the sharing invitation.
-        actions:
+        '@libre.graph.permissions.actions':
           type: array
           items:
             type: string
@@ -3719,11 +3766,13 @@ components:
         id:
           type: string
           description: The unique identifier of the permission among all permissions on the item. Read-only.
+          readOnly: true
         hasPassword:
           type: boolean
           description: |
             Indicates whether the password is set for this permission. This property only
             appears in the response. Optional. Read-only.
+          readOnly: true
         expirationDateTime:
           type: string
           description: An optional expiration date which limits the permission in time.
@@ -3732,19 +3781,6 @@ components:
         # this is always a single identity set because a permission always is tied to a single recipient (which can be a group).
           description: For user type permissions, the details of the users and applications for this permission. Only part of responses. Use the invitation property when creating shares.
           $ref: '#/components/schemas/sharePointIdentitySet'
-
-        # We could use grantedToIdentitiesV2 to share with guest or external members. 'Identities' here means that an external user is identified by an email aka a guest.
-        #grantedToIdentitiesV2:
-        #  description: For link type permissions, the details of the users to whom permission was granted. Read-only.
-        #  type: array
-        #  items:
-        #    $ref: '#/components/schemas/sharePointIdentitySet'
-
-        invitation:
-          description: |
-            Details of any associated sharing invitation for this permission. For now only used when creating shares with
-            internal users or groups. An invitation is converted into a grant and will not be part of responses.
-          $ref: '#/components/schemas/sharingInvitation'
         link:
           description: Provides the link details of the current permission, if it is a link type permissions. 
           $ref: '#/components/schemas/sharingLink'
@@ -3752,19 +3788,41 @@ components:
           type: array
           items:
             type: string
-        actions:
-          description: Use this to create a permission with custom actions.
-          type: array
-          items:
-            type: string
-        #shareId left out for now because it is part of the link
         grantedToIdentities:
           deprecated: true
-          # TODO should be deprecated in favor of properly using grantedToV2 with arrays of permissions
           description: For link type permissions, the details of the identity to whom permission was granted. This could be used to grant access to a an external user that can be identified by email, aka guest accounts.
           type: array
           items:
             $ref: '#/components/schemas/identitySet'
+        '@libre.graph.permissions.actions':
+          description: Use this to create a permission with custom actions.
+          type: array
+          items:
+            type: string
+        # follows the SAP UI vocabulary: https://github.com/SAP/odata-vocabularies/blob/main/vocabularies/UI.md
+        '@UI.Hidden':
+          description: Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true. Users can set this to hide permissons.
+          type: boolean
+
+        # unused. We could put public link token in here, but we currently only need the link property, anyway
+        #shareId:
+        #  description: A unique token that can be used to access this shared item via the shares API.
+        #  readOnly: true
+        #  type: string
+
+        # unused. We could use grantedToIdentitiesV2 to share with guest or external members. 'Identities' here means that an external user is identified by an email aka a guest.
+        #grantedToIdentitiesV2:
+        #  description: For link type permissions, the details of the users to whom permission was granted. Read-only.
+        #  type: array
+        #  items:
+        #    $ref: '#/components/schemas/sharePointIdentitySet'
+
+        # unused. invites are created with the driveItemInvite resource
+        #invitation:
+        #  description: |
+        #    Details of any associated sharing invitation for this permission. For now only used when creating shares with
+        #    internal users or groups. An invitation is converted into a grant and will not be part of responses.
+        #  $ref: '#/components/schemas/sharingInvitation'
     unifiedRoleDefinition:
       type: object
       description: |
@@ -3782,38 +3840,48 @@ components:
         id:
           description: The unique identifier for the role definition. Key, not nullable, Read-only. Inherited from entity. Supports $filter (`eq`, `in`).
           type: string
-        # isBuiltIn:
-        #   description: Flag indicating whether the role definition is part of the default set included in libre graph or a custom definition. Read-only. Supports $filter (`eq`, `in`).
-        #   type: boolean
-        # isEnabled:
-        #   description: Flag indicating whether the role is enabled for assignment. If `false` the role is not available for assignment. Read-only when **isBuiltIn** is `true`.
-        #   type: boolean
-        # leaving this out as it is already deprecated in msgraph and I do not think we need it right now
-        #resourceScopes:
-        #  type: string
-        #  description: |
-        #    List of the scopes or permissions the role definition applies to. Currently only / is supported.
-        #    Read-only when isBuiltIn is true. DO NOT USE. This will be deprecated soon. Attach scope to role assignment.
         rolePermissions:
           description: List of permissions included in the role.
           #description: List of permissions included in the role. Read-only when **isBuiltIn** is `true`.
           type: array
           items:
             $ref: '#/components/schemas/unifiedRolePermission'
-        # templateId:
-        #   description: |
-        #     Custom template identifier that can be set when isBuiltIn is `false` but is read-only when isBuiltIn is `true`.
-        #     This identifier is typically used if one needs an identifier to be the same across different directories.
-        #   type: string
-        # version:
-        #   description: Indicates version of the role definition. Read-only when **isBuiltIn** is `true`.
-        #   type: string
-        weight:
+        # follows the hugo weight
+        '@libre.graph.weight':
           description: |
             When presenting a list of roles the weight can be used to order them in a meaningful way.
             Lower weight gets higher precedence. So content with lower weight will come first. If set,
             weights should be non-zero, as 0 is interpreted as an unset weight.
           type: integer
+
+        # unused.
+        #isBuiltIn:
+        #  description: Flag indicating whether the role definition is part of the default set included in libre graph or a custom definition. Read-only. Supports $filter (`eq`, `in`).
+        #  type: boolean
+
+        # unused.
+        #isEnabled:
+        #  description: Flag indicating whether the role is enabled for assignment. If `false` the role is not available for assignment. Read-only when **isBuiltIn** is `true`.
+        #  type: boolean
+
+        # unused. already deprecated in msgraph and I do not think we need it right now
+        #resourceScopes:
+        #  type: string
+        #  description: |
+        #    List of the scopes or permissions the role definition applies to. Currently only / is supported.
+        #    Read-only when isBuiltIn is true. DO NOT USE. This will be deprecated soon. Attach scope to role assignment.
+
+        # unused. only useful for custom role definitions
+        #templateId:
+        #  description: |
+        #    Custom template identifier that can be set when isBuiltIn is `false` but is read-only when isBuiltIn is `true`.
+        #    This identifier is typically used if one needs an identifier to be the same across different directories.
+        #  type: string
+
+        # unused. only needed when versioning custom role definitions
+        #version:
+        #  description: Indicates version of the role definition. Read-only when **isBuiltIn** is `true`.
+        #  type: string
     unifiedRolePermission:
       type: object
       description: |
@@ -3905,11 +3973,13 @@ components:
             ```
             Conditions aren't supported for custom roles.
           type: string
-    #     excludedResourceActions:
-    #       description: Set of tasks that may not be performed on a resource. Not yet supported.
-    #       type: array
-    #       items:
-    #         type: string
+
+        # unused. not even supported in ms graph
+        #excludedResourceActions:
+        #  description: Set of tasks that may not be performed on a resource. Not yet supported.
+        #  type: array
+        #  items:
+        #    type: string
     odata.error:
       required:
         - error

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -275,6 +275,589 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/drives/{drive-id}/items/{item-id}/createLink':
+    post:
+      tags:
+        - drives.permissions
+      summary: Create a sharing link for a DriveItem
+      operationId: CreateLink
+      description: |
+        You can use createLink action to share a driveItem via a sharing link.
+
+        The **createLink** action will create a new sharing link if the specified link type doesn't already exist
+        for the calling application. If a sharing link of the specified type already exists for the app, the
+        existing sharing link will be returned.
+
+        DriveItem resources inherit sharing permissions from their ancestors.
+      
+        ## Link types
+
+        For now, The following values are allowed for the type parameter.
+        
+        | Type value      | Description                                                                                                                                                                                                           |
+        | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+        | view            | Creates a read-only link to the driveItem.                                                                                                                                                                            |
+        | edit            | Creates an read-write link to the driveItem.                                                                                                                                                                          |
+        | blocksDownload  | Creates a read-only link that blocks download to the driveItem.                                                                                                                                                       |
+        | createOnly      | Creates an upload-only link to the driveItem.                                                                                                                                                                         |
+
+        More built in types might be added with a speaking value but clients **MUST** treat the value as an
+        opaque identifier as custom types will be using UUIDs.
+
+      #  | embed           | Creates an embeddable link to the driveItem.                                                                                                                                                                          |
+      #  | review          | Creates a review link to the driveItem.                                                                                                                                                                               |
+      #  | addressBar      | Creates the default link that is shown in the browser address bars for newly created files. The organization admin configures whether this link type is supported, and what features are supported by this link type. |
+      #  | adminDefault    | Creates the default link to the driveItem as determined by the administrator of the organization. The policy is enforced for the organization by the admin                                                            |
+
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: 'key: id of item'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: item
+      requestBody:
+        description: In the request body, provide a JSON object with the following parameters.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  description: Optional. The type of sharing link to create.
+                expirationDateTime:
+                  type: string
+                  description: Optional. A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission.
+                  format: date-time
+                password: 
+                  type: string
+                  description: Optional.The password of the sharing link that is set by the creator.
+
+                # to invite guests or specify which users should be sent the link we could add this
+                #recipients:
+                #  type: array
+                #  items:
+                #    $ref: '#/components/schemas/driveRecipient'
+                #  description: A collection of recipients who will receive access and the sharing link.
+
+                # can be added later
+                #scope:
+                #  type: string
+                #  description: Optional. The scope of link to create. Either `anonymous`, `organization`, or `users`.
+
+                # In ocis recipients configure if they want to be notified
+                #sendNotification:
+                #  type: boolean
+                #  description: Optional. If `true`, this method sends a sharing link in an email to users specified in recipients. The default value is `false`. Optional.
+
+                # not supported by ocis
+                #retainInheritedPermissions:
+                #  type: boolean
+                #  description: Optional. If `true` (default), any existing inherited permissions are retained on the shared item when sharing this item for the first time. If `false`, all existing permissions are removed when sharing for the first time.
+            examples:
+                create viewer link:
+                  value:
+                    type: "view"
+                create editor link with expiry:
+                  value:
+                    type: "edit"
+                    expirationDateTime: "2018-07-15T14:00:00.000Z"
+      responses:
+        '200':
+          description: Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/permission'
+              examples:
+                send viewer invite:
+                  value:
+                    - id: "7181275c-557e-4adf-8e44-abdcf5389b6a"
+                      link:
+                        type: "view"
+                        webUrl: "https://cloud.example.org/s/YlaySZdHCRHUDeE"
+                send editor invite with expiry:
+                  value:
+                    - id: "a373c812-d786-42ae-a65f-ed87ee4abd49"
+                      link:
+                        type: "edit"
+                        webUrl: "https://cloud.example.org/s/MlnTDkhcBlihNzO"
+        '207':
+          description: Partial success response TODO
+        default:
+          $ref: '#/components/responses/error'
+          # TODO add SendNotification errors as per https://learn.microsoft.com/en-us/graph/api/driveitem-invite?view=graph-rest-beta&tabs=http#sendnotification-errors
+      x-ms-docs-operation-type: operation
+  '/drives/{drive-id}/items/{item-id}/invite':
+    post:
+      tags:
+        - drives.permissions
+      summary: Send a sharing invitation
+      operationId: Invite
+      description: |
+        Sends a sharing invitation for a `driveItem`. A sharing invitation provides permissions to the
+        recipients and optionally sends them an email with a sharing link.
+
+        ## Roles property values
+        For now, roles are only identified by a uuid. There are no hardcoded aliases like `read` or `write` because role actions can be completely customized.
+      # FIXME we should add isBuiltIn and isEnabled to unifiedRoleDefinition so we can use speaking role ids in examples and establish a well defined set of roles.
+      # By throwing around only uuids we increase the risk of someone choosing an ambiguous or misleading displayname. We will have to define a set of default
+      # sharing permissions. For those we should use speaking ids.
+      #
+      #  For now, the following roles are considered built in:
+      #  
+      #  | Role    | Value   | Description                                                                                                           |
+      #  | ------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+      #  | Viewer  | `read`  | Provides the ability to read the metadata and contents of the item.                                                   |
+      #  | Editor  | `write` | Provides the ability to read and modify the metadata and contents of the item.                                        |
+      #  | Manager | `owner` | For project drives this represents the Manager role to mimic ms graph                                                 |
+      #
+      #  More built in roles will be added with a speaking value but clients **MUST** treat the value as an
+      #  opaque identifier as custom roles will be using UUIDs.
+
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: 'key: id of item'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: item
+      requestBody:
+        description: In the request body, provide a JSON object with the following parameters. To create a custom role submit a list of actions instead of roles.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/driveItemInvite'
+            examples:
+                send viewer invite:
+                  value:
+                    recipients:
+                    - objectId: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                    roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
+                send viewer invite to multiple recipients:
+                  value:
+                    recipients:
+                    - objectId: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                    - objectId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"
+                    roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
+                send editor invite with expiry:
+                  value:
+                    recipients:
+                    - objectId: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                    roles: [ "a1c6f73e-482e-4078-a629-bbecb205abb" ]
+                    expirationDateTime: "2018-07-15T14:00:00.000Z"
+                send manager invite to group:
+                  description: "Sharing with a groups requires setting the @libre.graph.recipient.type annotation."
+                  value:
+                    recipients:
+                    - "@libre.graph.recipient.type": group
+                      objectId: "167cbee2-0518-455a-bfb2-031fe0621e5d"
+                    roles: [ "dfa16e02-3d88-45d8-8894-5b33a7df637" ]
+                send invite to user granting custom actions:
+                  description: "A Custom role is just a collection of actions, in this case allowing the user to stat and move driveItems"
+                  value:
+                    recipients:
+                    - objectId: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                    actions: [ "libre.graph/driveItem/basic/read", "libre.graph/driveItem/path/update" ]
+      responses:
+        '200':
+          description: Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/permission'
+              examples:
+                send viewer invite:
+                  value:
+                    - id: "34646ab6-be32-43c9-89e6-987e0c237e9b"
+                      roles: [ "read" ]
+                      grantedToV2:
+                        - user:
+                            id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                            displayName: "Albert Einstein"
+                send editor invite with expiry:
+                  value:
+                    - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
+                      roles: [ "write" ]
+                      grantedToV2:
+                        - user:
+                            id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                            displayName: "Albert Einstein"
+                send viewer invite to multiple recipients:
+                  description: multiple permissions are returned as each has received a dedicated sharing id
+                  value:
+                    - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
+                      roles: [ "write" ]
+                      grantedToV2:
+                        - user:
+                            id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                            displayName: "Albert Einstein"
+                    - id: "b470677e-a7f5-4304-8ef5-f5056a21fff1"
+                      roles: [ "write" ]
+                      grantedToV2:
+                        - user:
+                            id: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"
+                            displayName: "Marie Skłodowska Curie"
+                send manager invite to group:
+                  value:
+                    - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
+                      roles: [ "owner" ]
+                      grantedToV2:
+                        - group:
+                            id: "167cbee2-0518-455a-bfb2-031fe0621e5d"
+                            displayName: "Philosophy Haters"
+        '207':
+          description: Partial success response TODO
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/odata.error'
+              examples:
+                secureSharingInvalidRequest:
+                  description: If the recipient was given via email, but does not belong to a known user account.
+                  value:
+                    - error:
+                      - code: invalidRequest
+                        message: Some users in the request cannot be invited securely.
+                        innerError:
+                          - code: secureSharingInvalidRequest
+                            date: "2023-09-14T12:27:15"
+                            request-id: b49f582d-9a0f-4731-ab0c-b9e50246ef58
+                            client-request-id: 832c7206-1a40-395c-e0d9-e85649b8b0b0
+        default:
+          $ref: '#/components/responses/error'
+          # TODO add SendNotification errors as per https://learn.microsoft.com/en-us/graph/api/driveitem-invite?view=graph-rest-beta&tabs=http#sendnotification-errors
+      x-ms-docs-operation-type: operation
+  '/drives/{drive-id}/items/{item-id}/permissions':
+    get:
+      tags:
+        - drives.permissions
+      summary: List the effective sharing permissions on a driveItem.
+      operationId: ListPermissions
+      description: |
+        The permissions collection includes potentially sensitive information and may not be available for every caller.
+
+        * For the owner of the item, all sharing permissions will be returned. This includes co-owners.
+        * For a non-owner caller, only the sharing permissions that apply to the caller are returned.
+        * Sharing permission properties that contain secrets (e.g. `shareId` and `webUrl`) are only returned for callers that are able to create the sharing permission.
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: 'key: id of item'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: item
+      responses:
+        '200':
+          description: Retrieved resource
+          content:
+            application/json:
+              schema:
+                title: Collection of permissions
+                type: object
+                properties:
+                  '@libre.graph.permissions.roles.allowedValues':
+                    type: array
+                    description: A list of role definitions that can be chosen for the resource.
+                    items:
+                      $ref: '#/components/schemas/unifiedRoleDefinition'
+                  '@libre.graph.permissions.actions.allowedValues':
+                    type: array
+                    description: |
+                      A list of actions that can be chosen for a custom role.
+
+                      Following the CS3 API we can represent the CS3 permissions by mapping them to driveItem properties or relations like this:
+                      | [CS3 ResourcePermission](https://cs3org.github.io/cs3apis/#cs3.storage.provider.v1beta1.ResourcePermissions) | action | comment |
+                      | ------------------------------------------------------------------------------------------------------------ | ------ | ------- |
+                      | `stat` | `libre.graph/driveItem/basic/read` | `basic` because it does not include versions or trashed items |
+                      | `get_quota` | `libre.graph/driveItem/quota/read` | read only the `quota` property |
+                      | `get_path` | `libre.graph/driveItem/path/read` | read only the `path` property |
+                      | `move` | `libre.graph/driveItem/path/update` | allows updating the `path` property of a CS3 resource |
+                      | `delete` | `libre.graph/driveItem/standard/delete` | `standard` because deleting is a common update operation |
+                      | `list_container` | `libre.graph/driveItem/children/read` | |
+                      | `create_container` | `libre.graph/driveItem/children/create` | |
+                      | `initiate_file_download` | `libre.graph/driveItem/content/read` | `content` is the property read when initiating a download |
+                      | `initiate_file_upload` | `libre.graph/driveItem/upload/create` | `uploads` are a separate property. postprocessing creates the `content` |
+                      | `add_grant` | `libre.graph/driveItem/permissions/create` | |
+                      | `list_grant` | `libre.graph/driveItem/permissions/read` | |
+                      | `update_grant` | `libre.graph/driveItem/permissions/update` | |
+                      | `remove_grant` | `libre.graph/driveItem/permissions/delete` | |
+                      | `deny_grant` | `libre.graph/driveItem/permissions/deny` | uses a non CRUD action `deny` |
+                      | `list_file_versions` | `libre.graph/driveItem/versions/read` | `versions` is a `driveItemVersion` collection |
+                      | `restore_file_version` | `libre.graph/driveItem/versions/update` | the only `update` action is restore |
+                      | `list_recycle` | `libre.graph/driveItem/deleted/read` | reading a driveItem `deleted` property implies listing |
+                      | `restore_recycle_item` | `libre.graph/driveItem/deleted/update` | the only `update` action is restore |
+                      | `purge_recycle` | `libre.graph/driveItem/deleted/delete` | allows purging deleted `driveItems` |
+                    items:
+                      type: string
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/permission'
+                  #  maxItems: 100
+                  #'@odata.nextLink':
+                  #  type: string
+              example:
+                '@libre.graph.permissions.roles.allowedValues':
+                  - id: 7ccc2a61-9615-4063-a80a-eb7cd8e59d8
+                    description: "Allows reading the shared file or folder"
+                    displayName: Viewer
+                    # we don't want to reproduce all the individual role permissions, that is what the /roleManagement/permissions/roleDefinitions endpoint is for
+                    # to build a custom role 
+                    #rolePermissions:
+                    #  - allowedResourceActions:
+                    #    - libre.graph/driveItem/basic/read
+                    #    - libre.graph/driveItem/permissions/read
+                    #    - libre.graph/driveItem/upload/create
+                    #    condition: "@Subject.objectId Any_of @Resource.grantee"
+                    weight: 1
+                  - id: a1c6f73e-482e-4078-a629-bbecb205abb
+                    description: "Allows reading and writing the shared file or folder"
+                    displayName: Editor
+                    #rolePermissions:
+                    #  - allowedResourceActions:
+                    #    - libre.graph/driveItem/standard/allTasks
+                    #    condition: "@Subject.objectId Any_of @Resource.grantee"
+                    weight: 2
+                  - id: dfa16e02-3d88-45d8-8894-5b33a7df637
+                    description: "Allows managing a space"
+                    displayName: Manager
+                    #rolePermissions:
+                    #  - allowedResourceActions:
+                    #    - libre.graph/drive/standard/allTasks 
+                    #    condition: "@Subject.objectId Any_of @Resource.grantee"
+                    weight: 3
+                  - id: 4916f47e-66d5-49bb-9ac9-748ad00334b
+                    description: "Allows creating new files"
+                    displayName: File Drop
+                    #rolePermissions:
+                    #  - allowedResourceActions:
+                    #      libre.graph/driveItem/upload/create
+                    #    condition: "@Subject.objectId Any_of @Resource.grantee"
+                    weight: 4
+                '@libre.graph.permissions.actions.allowedValues': [
+                    "libre.graph/driveItem/basic/read",
+                    "libre.graph/driveItem/permissions/read",
+                    "libre.graph/driveItem/upload/create",
+                    "libre.graph/driveItem/standard/allTasks",
+                    "libre.graph/driveItem/upload/create"
+                ]
+
+                value:
+                  - id: "67445fde-a647-4dd4-b015-fc5dafd2821d"
+                    roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
+                    link:
+                      type: "view"
+                      webUrl: "https://cloud.example.org/s/fhGBMIkKFEHWysj"
+                  - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
+                    roles: [ "a1c6f73e-482e-4078-a629-bbecb205abb" ]
+                    expirationDateTime: "2018-07-15T14:00:00.000Z"
+                    grantedToV2:
+                      - user:
+                          id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                          displayName: "Albert Einstein"
+                    link:
+                      webUrl: "https://cloud.example.org/s/kXJpiJmMnQxVlaT"
+                  - id: "dda0bb77-ffe7-4867-a2bf-28af65b46aa3"
+                    actions: [ "libre.graph/driveItem/basic/read", "libre.graph/driveItem/path/update" ]
+                    grantedToV2:
+                      - user:
+                          id: "058bff95-6708-4fe5-91e4-9ea3d377588b"
+                          displayName: "Maurice Moss"
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/drives/{drive-id}/items/{item-id}/permissions/{perm-id}':
+    get:
+      tags:
+        - drives.permissions
+      summary: Get sharing permission for a file or folder
+      operationId: GetPermission
+      description: |
+        Return the effective sharing permission for a particular permission resource.
+
+      # TODO do we need to implement inherited permissions from the start?
+      #  Effective permissions of an item can come from two sources: permissions set directly on the item itself or permissions that are inherited from the item's ancestors.
+      #
+      #  Callers can differentiate if the permission is inherited or not by checking the `inheritedFrom` property. This property is an ItemReference resource referencing the ancestor that the permission is inherited from.
+      #
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: 'key: id of item'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: item
+        - name: perm-id
+          in: path
+          description: 'key: id of permission'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: permission
+      responses:
+        '200':
+          description: Retrieved resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/permission'
+              examples:
+                edit permission:
+                  value:
+                    id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
+                    roles: [ "write" ]
+                    grantedToV2:
+                      - user:
+                          id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                          displayName: "Albert Einstein"
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - drives.permissions
+      summary: Update sharing permission
+      operationId: UpdatePermission
+      description: |
+        Update the properties of a sharing permission by patching the permission resource.
+
+        Only the `roles`, `expirationDateTime` and `password` properties can be modified this way.
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: 'key: id of item'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: item
+        - name: perm-id
+          in: path
+          description: 'key: id of permission'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: permission
+        #- name: If-Match
+        #  in: header
+        #  description: |
+        #    If this request header is included and the eTag (or cTag) provided does not match the current tag on the item,
+        #    a `412 Precondition Failed`` response is returned and the item will not be updated.
+        #  schema:
+        #    type: string
+      requestBody:
+        description: New property values
+        content:
+          application/json:
+              schema:
+                $ref: '#/components/schemas/permission'
+              example:
+                roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
+        required: true
+      responses:
+        '200':
+          description: Updated permission
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/permission'
+              example:
+                  id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
+                  roles: [ "7ccc2a61-9615-4063-a80a-eb7cd8e59d8" ]
+                  expirationDateTime: "2018-07-15T14:00:00.000Z"
+                  grantedToV2:
+                    - user:
+                        id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                        displayName: "Albert Einstein"
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - drives.permissions
+      summary: Delete entity from groups
+      operationId: DeletePermission
+      description: |
+        Remove access to a DriveItem.
+
+        Only sharing permissions that are not inherited can be deleted. The `inheritedFrom` property must be `null`.
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: 'key: id of item'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: item
+        - name: perm-id
+          in: path
+          description: 'key: id of permission'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: permission
+        #- name: If-Match
+        #  in: header
+        #  description: |
+        #    If this request header is included and the eTag (or cTag) provided does not match the current tag on the item,
+        #    a `412 Precondition Failed`` response is returned and the item will not be updated.
+        #  schema:
+        #    type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   '/drives/{drive-id}/root':
     get:
       tags:
@@ -645,6 +1228,110 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /me/drive/sharedByMe:
+    get:
+      tags:
+        - me.drive
+      summary: Get a list of driveItem objects shared by the current user.
+      operationId: ListSharedByMe
+      description: |
+        The `driveItems` returned from the `sharedByMe` method always include the `permissions` relation that indicates they are shared items.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                title: Collection of driveItems
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/driveItem'
+                  #  maxItems: 20
+                  #'@odata.nextLink':
+                  #  type: string
+              example:
+                value:
+                  - id: 78363031-03ef-4eda-84a2-243a691a13cd
+                    createdDateTime: "2020-02-19T14:23:25.52Z"
+                    # not yet supported by ocis
+                    #cTag: "adDpDMTI2NDRBMTRCMEE3NzUwITEzNzkuNjM3NjYyNzQ5NjU1MDMwMDAw"
+                    eTag: "aQzEyNjQ0QTE0QjBBNzc1MCExMzc5LjQ"
+                    lastModifiedDateTime: "2021-09-03T14:09:25.503Z"
+                    name: "March Proposal.docx"
+                    parentReference:
+                      driveId: "1991210caf"
+                      driveType: personal
+                    permissions:
+                      - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
+                        roles: [ "write" ]
+                        grantedToV2:
+                          - user:
+                              id: "4c510ada-c86b-4815-8820-42cdf82c3d51"
+                              displayName: "Albert Einstein"
+                      - id: "81d5bad3-3eff-410a-a2ea-eda2d14d4474"
+                        roles: [ "read" ]
+                        grantedToV2:
+                          - user:
+                              id: "48016357-346a-443e-bf7a-945c9448a99b"
+                              displayName: "Marie Curie"
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+
+  /me/drive/sharedWithMe:
+    get:
+      tags:
+        - me.drive
+      summary: Get a list of driveItem objects shared with the owner of a drive.
+      operationId: ListSharedWithMe
+      description: |
+        The `driveItems` returned from the `sharedWithMe` method always include the `remoteItem` facet that indicates they are items from a different drive.
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                title: Collection of driveItems
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/driveItem'
+                  #  maxItems: 20
+                  #'@odata.nextLink':
+                  #  type: string
+              example:
+                value:
+                  - id: 78363031-03ef-4eda-84a2-243a691a13cd
+                    createdDateTime: "2020-02-19T14:23:25.52Z"
+                    cTag: "adDpDMTI2NDRBMTRCMEE3NzUwITEzNzkuNjM3NjYyNzQ5NjU1MDMwMDAw"
+                    eTag: "aQzEyNjQ0QTE0QjBBNzc1MCExMzc5LjQ"
+                    lastModifiedDateTime: "2021-09-03T14:09:25.503Z"
+                    name: "March Proposal.docx"
+                    parentReference:
+                      driveId: "1991210caf"
+                      driveType: personal
+                    remoteItem:
+                      id: 02d7a7df-a6f7-44cc-848a-3c98f7dd5046
+                      name: "March Proposal.docx"
+                      size: 19121
+                      shared: 
+                        sharedDateTime: "2020-02-19T14:23:25.52Z"
+                        owner:
+                          user:
+                            displayName: "Albert Einstein"
+                            id: "44feab10d55e9871"
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+                        
   /users:
     get:
       tags:
@@ -2071,11 +2758,9 @@ paths:
               examples:
                 Viewer:
                   value:
-                    id: read
+                    id: 7ccc2a61-9615-4063-a80a-eb7cd8e59d8
                     description: "Allows reading the shared file or folder"
                     displayName: Viewer
-                    #isBuiltIn: true
-                    #isEnabled: true
                     rolePermissions:
                       - allowedResourceActions:
                         - libre.graph/driveItem/basic/read
@@ -2083,11 +2768,9 @@ paths:
                     weight: 1
                 Editor:
                   value:
-                    id: write
+                    id: a1c6f73e-482e-4078-a629-bbecb205abb
                     description: "Allows reading and writing the shared file or folder"
                     displayName: Editor
-                    #isBuiltIn: true
-                    #isEnabled: true
                     rolePermissions:
                       - allowedResourceActions:
                         - libre.graph/driveItem/standard/allTasks 
@@ -2095,11 +2778,9 @@ paths:
                     weight: 2
                 Manager:
                   value:
-                    id: owner
+                    id: dfa16e02-3d88-45d8-8894-5b33a7df637
                     description: "Allows managing a space"
                     displayName: Manager
-                    #isBuiltIn: true
-                    #isEnabled: true
                     rolePermissions:
                       - allowedResourceActions:
                         - libre.graph/drive/standard/allTasks 
@@ -2107,11 +2788,9 @@ paths:
                     weight: 3
                 File Drop:
                   value:
-                    id: a-u-u-id or uniquerolename?
+                    id: 4916f47e-66d5-49bb-9ac9-748ad00334b
                     description: "Allows creating new files"
                     displayName: File Drop
-                    #isBuiltIn: false
-                    #isEnabled: false
                     rolePermissions:
                       - allowedResourceActions:
                         - libre.graph/driveItem/standard/create
@@ -2354,6 +3033,27 @@ components:
           items:
               $ref: '#/components/schemas/driveItem'
           description: A collection of special drive resources.
+    driveRecipient:
+      type: object
+      description: |
+        Represents a person, group, or other recipient to share a drive item with using the invite action.
+
+        When using invite to add permissions, the `driveRecipient` object would specify the `email`, `alias`,
+        or `objectId` of the recipient. Only one of these values is required; multiple values are not accepted.
+      properties:
+        #alias:
+        #  type: string
+        #  description: The alias of the domain object, for cases where an email address is unavailable (e.g. groups).
+        #email:
+        #  type: string
+        #  description: The email address for the recipient, if the recipient has an associated email address.
+        objectId:
+          type: string
+          description: The unique identifier for the recipient in the directory.
+        "@libre.graph.recipient.type":
+          type: string
+          description: When the recipient is referenced by objectId this annotation is used to differentiate `user` and `group` recipients.
+          default: user
     identitySet:
       type: object
       description: Optional. User account.
@@ -2367,9 +3067,27 @@ components:
         user:
           $ref: '#/components/schemas/identity'
           description: Optional. The user associated with this action.
+        # this is not part of the ms graph api. there, only the sharepointIdentitySet used in grantedToV2 has a group 
         group:
           $ref: '#/components/schemas/identity'
           description: Optional. The group associated with this action.
+    sharePointIdentitySet:
+      type: object
+      description: This resource is used to represent a set of identities associated with various events for an item, such as created by or last modified by.
+      properties:     
+        #application:
+        #  $ref: '#/components/schemas/identity'
+        #  description: Optional. The application associated with this action.
+        #device:
+        #  $ref: '#/components/schemas/identity'
+        #  description: Optional. The device associated with this action.
+        user:
+          $ref: '#/components/schemas/identity'
+          description: Optional. The user associated with this action.
+        group:
+          $ref: '#/components/schemas/identity'
+          description: Optional. The group associated with this action.
+        # other properties omitted for now
     identity:
       type: object
       required:
@@ -2403,6 +3121,70 @@ components:
           type: string
           writeOnly: true
           description: The user's password
+    sharingInvitation:
+      description: The `SharingInvitation` resource groups invitation-related data items into a single structure.
+      type: object
+      properties:
+        email:
+          type: string
+          description: The email address provided for the recipient of the sharing invitation.
+          readOnly: true
+        invitedBy:
+          $ref: '#/components/schemas/identitySet'
+          description: Provides information about who sent the invitation that created this permission, if that information is available.
+          readOnly: true
+        signInRequired:
+          type: boolean
+          description: If `true` the recipient of the invitation needs to sign in in order to access the shared item.
+          readOnly: true
+    sharingLink:
+      description: |
+        The `SharingLink` resource groups link-related data items into a single structure.
+
+        If a `permission` resource has a non-null `sharingLink` facet, the permission represents a sharing link (as opposed to permissions granted to a person or group).
+      type: object
+      properties:
+        application:
+          $ref: '#/components/schemas/identity'
+          description: The app the link is associated with.
+        type:
+          type: string
+          enum: [view, edit, blocksDownload, createOnly]
+          description: |
+            The type of the link created.
+
+            | Value          | Description                                                                                                                                                                                                           |
+            | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+            | view           | Creates a read-only link to the driveItem.                                                                                                                                                                            |
+            | edit           | Creates an read-write link to the driveItem.                                                                                                                                                                          |
+            | blocksDownload | Creates a read-only link that blocks download to the driveItem.                                                                                                                                                       |
+            | createOnly     | Creates an upload-only link to the driveItem.                                                                                                                                                                         |
+          # there are more link types available in https://learn.microsoft.com/en-us/graph/api/driveitem-createlink?view=graph-rest-beta&tabs=http#link-types
+          #  | review         | Creates a review link to the driveItem.                                                                                                                                                                               |
+          #  | embed          | Creates an embeddable link to the driveItem.                                                                                                                                                                          |
+          #  | addressBar     | Creates the default link that is shown in the browser address bars for newly created files. The organization admin configures whether this link type is supported, and what features are supported by this link type. |
+          #  | adminDefault   | Creates the default link to the driveItem as determined by the administrator of the organization. The policy is enforced for the organization by the admin                                                            |            
+        scope:
+          type: string
+          enum: [anonymous, organization, existingAccess, users]
+          description: |
+            The scope of the link represented by this permission. Value `anonymous` indicates the link is usable by anyone, `organization` indicates the link is only usable for users signed into the same tenant.
+
+            | Value          | Description                                                                                                           |
+            | -------------- | --------------------------------------------------------------------------------------------------------------------- |
+            | anonymous      | Anyone with the link has access, without needing to sign in. This may include people outside of your organization.    |
+            | organization   | Anyone signed into your organization (tenant) can use the link to get access.                                         |
+            | existingAccess | Only people who have already been granted access to the item through other means can access the item using this link. |
+            | users          | The link grants access only to a specific list of people.                                                             |
+        preventsDownload:
+          type: boolean
+          description: If `true` then the user can only use this link to view the item on the web, and cannot use it to download the contents of the item.
+        webHtml:
+          type: string
+          description: For `embed` links, this property contains the HTML code for an `<iframe>` element that will embed the item in a webpage.
+        webUrl:
+          type: string
+          description: A URL that opens the item in the browser on the website.
     user:
       description: Represents an Active Directory user object.
       type: object
@@ -2584,6 +3366,54 @@ components:
             $ref: '#/components/schemas/permission'
           description: The set of permissions for the item. Read-only. Nullable.
           readOnly: true
+    driveItemInvite:
+      type: object
+      properties:
+        recipients:
+          type: array
+          items:
+            $ref: '#/components/schemas/driveRecipient'
+          description: A collection of recipients who will receive access and the sharing invitation. Currently, only internal users or gorups are supported.
+        roles:
+          type: array
+          items:
+            type: string
+          description: Specifies the roles that are to be granted to the recipients of the sharing invitation.
+        actions:
+          type: array
+          items:
+            type: string
+          description: Specifies the actions that are to be granted to the recipients of the sharing invitation, in effect creating a custom role.
+        expirationDateTime:
+          type: string
+          description: Specifies the dateTime after which the permission expires.
+          format: date-time
+
+        # Can be added later
+        #message:
+        #  type: string
+        #  description: A plain text formatted message that is included in the sharing invitation.
+        #  maxLength: 2000
+
+        # Internal shares always require login
+        #requireSignIn:
+        #  type: boolean
+        #  description: Specifies whether the recipient of the invitation is required to sign-in to view the shared item.
+
+        # In ocis recipients configure if they want to be notified
+        #sendInvitation:
+        #  type: boolean
+        #  description: If `true`, a sharing link is sent to the recipient. Otherwise, a permission is granted directly without sending a notification.
+        
+        # internal shares do not have a password
+        #password: 
+        #  type: string
+        #  description: The password set on the invite by the creator. Optional .
+
+        # not supported by ocis
+        #retainInheritedPermissions:
+        #  type: boolean
+        #  description: Optional. If `true` (default), any existing inherited permissions are retained on the shared item when sharing this item for the first time. If `false`, all existing permissions are removed when sharing for the first time.
     deleted:
       type: object
       description: Information about the deleted state of the item. Read-only.
@@ -2699,6 +3529,9 @@ components:
         driveAlias:
           type: string
           description: "The drive alias can be used in clients to make the urls user friendly. Example: 'personal/einstein'. This will be used to resolve to the correct driveID."
+        #driveType:
+        # wie kommt man zum drive? web möchte im ui den pfad anzeigen, der wird aus dem driveAlias gebaut, aber die brauchen auch den driveType um das datenmodell konsistent zu haben
+        # momentan machen sie einen ocs list shares request und sichen sich dann den mountpoint anhand der id raus, aber cern möchte IMMER den personal space dazu sehen, incl pfad
         path:
           type: string
           description: "The relative path of the item in relation to its drive root."
@@ -2871,21 +3704,67 @@ components:
       description: 'Represents a Directory object. Read-only.'
     permission:
       type: object
-      description: 'The Permission resource provides information about a sharing permission granted for a DriveItem resource.'
+      description: |
+        The Permission resource provides information about a sharing permission granted for a DriveItem resource.
+
+        ### Remarks
+
+        The Permission resource uses *facets* to provide information about the kind of permission represented by the resource.
+
+        Permissions with a `link` facet represent sharing links created on the item. Sharing links contain a unique token that provides access to the item for anyone with the link.
+
+        Permissions with a `invitation` facet represent permissions added by inviting specific users or groups to have access to the file.
       readOnly: true
       properties:
+        id:
+          type: string
+          description: The unique identifier of the permission among all permissions on the item. Read-only.
+        hasPassword:
+          type: boolean
+          description: |
+            Indicates whether the password is set for this permission. This property only
+            appears in the response. Optional. Read-only.
         expirationDateTime:
           type: string
           description: An optional expiration date which limits the permission in time.
           format: date-time
-        grantedToIdentities:
-          type: array
-          items:
-            $ref: '#/components/schemas/identitySet'
+        grantedToV2:
+        # this is always a single identity set because a permission always is tied to a single recipient (which can be a group).
+          description: For user type permissions, the details of the users and applications for this permission. Only part of responses. Use the invitation property when creating shares.
+          $ref: '#/components/schemas/sharePointIdentitySet'
+
+        # We could use grantedToIdentitiesV2 to share with guest or external members. 'Identities' here means that an external user is identified by an email aka a guest.
+        #grantedToIdentitiesV2:
+        #  description: For link type permissions, the details of the users to whom permission was granted. Read-only.
+        #  type: array
+        #  items:
+        #    $ref: '#/components/schemas/sharePointIdentitySet'
+
+        invitation:
+          description: |
+            Details of any associated sharing invitation for this permission. For now only used when creating shares with
+            internal users or groups. An invitation is converted into a grant and will not be part of responses.
+          $ref: '#/components/schemas/sharingInvitation'
+        link:
+          description: Provides the link details of the current permission, if it is a link type permissions. 
+          $ref: '#/components/schemas/sharingLink'
         roles:
           type: array
           items:
             type: string
+        actions:
+          description: Use this to create a permission with custom actions.
+          type: array
+          items:
+            type: string
+        #shareId left out for now because it is part of the link
+        grantedToIdentities:
+          deprecated: true
+          # TODO should be deprecated in favor of properly using grantedToV2 with arrays of permissions
+          description: For link type permissions, the details of the identity to whom permission was granted. This could be used to grant access to a an external user that can be identified by email, aka guest accounts.
+          type: array
+          items:
+            $ref: '#/components/schemas/identitySet'
     unifiedRoleDefinition:
       type: object
       description: |

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -3260,9 +3260,10 @@ components:
           type: string
           description: Path that can be used to navigate to the item. Read-only.
           readOnly: true
-        shareId:
-          type: string
-          description: 'A unique identifier for a shared resource that can be accessed via the [Shares][] API.'
+        # unused. this is the token but we reference shares, even links, by id
+        #shareId:
+        #  type: string
+        #  description: 'A unique identifier for a shared resource that can be accessed via the [Shares][] API.'
     driveItem:
       description: Reprensents a resource inside a drive. Read-only.
       readOnly: true


### PR DESCRIPTION
libregraph API spec for the sharing ADR in https://github.com/owncloud/ocis/pull/6995

When following a share lifecycle, the following OCS requests can be replaced with these libregraph counterparts:

## List shares on a resource (includes sharing options)
**OCS**: web calls two endpoints:
- `/ocs/v1.php/apps/files_sharing/api/v1/shares?path={space-relative-path}&space_ref={space-id}&reshares=true`
- `/ocs/v1.php/apps/files_sharing/api/v1/shares?path={space-relative-path}&space_ref={space-id}&shared_with_me=true`

**ms graph**: `/drives/{drive-id}/items/{drive-item-id}/permissions`
```json
{
    "value": [
        {
            "id": "collaborative-share-id",
            "roles": [
                "write"
            ],
            "grantedToV2": {
                "user": {
                    "displayName": "Albert Einstein",
                    "id": "4c510ada-c86b-4815-8820-42cdf82c3d51"
                }
            },
        },
        {
            "id": "public-link-share-id",
            "roles": [
                "read"
            ],
            "link": {
                "webUrl": "https://cloud.example.com/s/CMXOrzoFODpHKsS"
            }
        }
    ]
}
```
**libre graph**: for now we stick to two kinds of permissions:
* `grantedToV2` for internal user or group shares
* `link` for public link shares
_jfd: roles are currently hardcoded to `read`, `write` and `owner`. We can make them customizable but I'll show that at the end of this description_
```json
{
    "value": [
        {
            "id": "collaborative-share-id",
            "roles": [
                "write"
            ],
            "grantedToV2": {
                "user": {
                    "displayName": "Albert Einstein",
                    "id": "4c510ada-c86b-4815-8820-42cdf82c3d51"
                }
            },
        },
        {
            "id": "public-link-share-id",
            "roles": [
                "read"
            ],
            "link": {
                "webUrl": "https://cloud.example.com/s/CMXOrzoFODpHKsS"
            }
        }
    ]
}
```


## Search for recipient (not part of this PR)
**OCS**: `/ocs/v2.php/apps/files_sharing/api/v1/sharees?search=einst&itemType=(folder|file)&page=1&perPage=200&format=json`
**ms graph**: [`/me/people?$search="einst"`](https://learn.microsoft.com/en-us/graph/api/user-list-people?view=graph-rest-beta&tabs=http) is used to interact with users that are [relevant or in a working-with relationship](https://learn.microsoft.com/en-us/graph/people-insights-overview#including-a-person-as-relevant-or-working-with). The returned list of [person](https://learn.microsoft.com/en-us/graph/api/resources/person?view=graph-rest-beta) entities has a  [`personType` property](https://learn.microsoft.com/en-us/graph/search-concept-person#person-types) to differentiate types of groups and users.
**libre graph**: `/me/people?$search="einst"` is the only endpoint we need, I think. For now, a `$search="einst"` parameter can be used instead of the OCS sharee call.

**Note**: There is a difference between `$search="foo bar"` and `$search=foo bar`. To mimic OCS the request has to quote the typed in string.*

## Create a share with user or group
**OCS**:  
```
POST ocs/v1.php/apps/files_sharing/api/v1/shares

shareType=0
shareWith=marie
path=/Neuer Ordner
space_ref=storage-users-1$some-admin-user-id-0000-000000000000!71beebf5-0057-4104-a814-bb49712eaab9
permissions=31
role=editor
```

**ms graph**: sharing wit a user is done by posting an `invite`
```json
POST /drives/{drive-id}/items/{drive-item-id}/invite

{
    "requireSignIn": true,
    "recipients": [
        {
            "email": "einstein@example.org"
        }
    ],
    "roles": [
        "read"
    ]
}
```

response:
```json
{
    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#Collection(permission)",
    "value": [
        {
            "@odata.type": "#microsoft.graph.permission",
            "id": "r_mJa3kBqBtkotIl8tWt9nVA2L1",
            "roles": [
                "read"
            ],
            "shareId": "s!BFB3CkuhRCbBgmcZvWieFTBrBGQ",
            "expirationDateTime": "0001-01-01T00:00:00Z",
            "hasPassword": false,
            "grantedToV2": {
                "user": {
                    "id": "einstein@example.org"
                }
            },
            "invitation": {
                "email": "einstein@example.org",
                "signInRequired": true
            },
            "link": {
                "webUrl": "https://1drv.ms/f/s!BFB3CkuhRCbBgmcZvWieFTBrBGQ"
            }
        }
    ]
}
```
It seems the response does not use `grantedToV2`. And when `requireSignIn` is left out or `false` it will happily create a link `webUrl` that allows browsing the file. 

**libre graph**: sharing wit a user is done by posting an `invite`. While ms graph uses `email` to identify a recipient libre graph assumes internal shares are created using the `objectId` (the users `id`) 

```json
POST /drives/{drive-id}/items/{drive-item-id}/invite

{
    "requireSignIn": true,
    "recipients": [
        {
            "objectId": "4c510ada-c86b-4815-8820-42cdf82c3d51"
        }
    ],
    "roles": [
        "read"
    ]
}
```

response:
```json
{
    "value": [
        {
            "id": "8c5ed185-1fcb-4c5a-8569-b9ed04293204",
            "roles": [
                "read"
            ],
            "grantedToV2": {
                "user": {
                    "id": "4c510ada-c86b-4815-8820-42cdf82c3d51"
                }
            },
        }
    ]
}
```
_jfd: multiple recipients can be sent in the same request. Each will receive a dedicated permissions object with their own id. WChen an error occurs a 207 multistatus response will be returned, similar to https://learn.microsoft.com/en-us/graph/api/site-follow?view=graph-rest-1.0&tabs=http#response-1 which shows an examplo where one of the entries contains an error_
request:
```json
POST /drives/{drive-id}/items/{drive-item-id}/invite

{
    "recipients": [
        {
          "objectId": "4c510ada-c86b-4815-8820-42cdf82c3d51"
        },
        {
          "objectId": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"
        }
    ],
    "roles": [
        "read"
    ]
}
```

response:
```json
{
  "value": [
    {
      "id": "81d5bad3-3eff-410a-a2ea-eda2d14d4474",
      "roles": [
        "write"
      ],
      "grantedToV2": [
        {
          "user": {
            "id": "4c510ada-c86b-4815-8820-42cdf82c3d51",
            "displayName": "Albert Einstein"
          }
        }
      ]
    },
    {
      "id": "b470677e-a7f5-4304-8ef5-f5056a21fff1",
      "error": {
        "@odata.type": "#odata.error.main",
        "code": "invalidRequest",
        "message": "The user id that is provided in the request is incorrect",
        "innerError": {
            "code": "itemNotFound",
            "errorType": "expected",
            "message": "Unknown user id b470677e-a7f5-4304-8ef5-f5056a21fff1 ",
        }
      }
    }
  ]
}
```

## Shared by me
List shares created by the currently logged in user
**OCS**: is called Shared With Others, see below
**ms graph**: odata query not implemented
**onedrive web**: can list shares by me in the web ui. maybe something is coming to ms graph as well?
**libre graph**: `/me/drive/sharedByMe` (only includes shares created by the current user)

## Shared with others (not part of this PR)
Includes shares in project spaces that can be managed by the current user because he is a manager of the space. He does not need to be the creator of the share.
**OCS**: `/ocs/v1.php/apps/files_sharing/api/v1/shares?reshares=true&include_tags=false&share_types=0,1,4,6`
**ms graph**: odata query not implemented
**libre graph**: does not exist, but we could add a new `/me/drive/sharedWithOthers` endpoint

***Note**: the OCS `share_types` are 0 = User, 1 = Group, 3 = public link, 4 = guest, 6 = federated share, 7 = federated group / space member user (OH great we have a clash here), 8 = space member group.*

***Hint**: There is a difference in the concept of shares. In OC10 shares are tied to a user. In OCIS they are tied to a space. The Owner/All managers of a space can collaboratively manage all shares in a personal/project space.*

## Shared with me
As the recipient you want to get a list of all driveItems that have been shared with you.
**OCS**: `/ocs/v1.php/apps/files_sharing/api/v1/shares?include_tags=false&state=all&shared_with_me=true`
**ms graph**: `/me/drive/sharedWithMe`
**libre graph**: `/me/drive/sharedWithMe`
The endpoint returns a `collection(driveItem)` that contains both: mounted and unmounted driveItems. shared driveItems are wrapped in another driveItem representing the mountpoint as on the ms graph API. But there are two deviations from the ms graph API: 
1. Shared driveItems that have not been mounted are **not** wrapped by another drive item. The ms graph api always wraps the shared driveItem. We do not want to do that on the fly as the driveItem representing the mountpoint would not have a parent id as it is unmounted. We will only wrap the shared driveItem with a mount point if the share has been created.
2. libre graph for now does not use the `shared` property but expands the `permissions` relation as it contains all necessary information. This might change if we think the `shared` property is enough to show the necessary indicators. It would be faster than listing all details of the permission.
3. libre graph uses a `@libre.graph.hidden` annotation on driveItems to indicate 
```json
{
  "value": [
    {
      "id": "u-u-id-of-mountpoint",
      "name": "November-December Ad Proposals.pptx",
      "size": 100984,
      "parentReference": {
        "driveType": "personal",
        "driveId": "u-u-id-of-drive-containing-the-pointpoint",
        "id": "parent-u-u-id"
      },
      "remoteItem": {
        "id": "u-u-id-of-shared-driveItem",
        "name": "November-December Ad Proposals.pptx",
        "size": 100984,
        "parentReference": {
          "driveType": "personal",
          "driveId": "u-u-id-of-drive-containing-the-item"
          // no "id" because recipient is not allowed to see parent
        },
        "permissions": [
          {
            "@libre.graph.hidden": false,
            "id": "92f276ac-827a-40c1-9d9c-bb41a628ce71",
            "roles": [
              "write"
            ],
            "grantedToV2": {
              "user": {
                "displayName": "Jörn Dreyer",
                "id": "c12644a14b0a7750"
              }
            }
          }
        ]
      }
    },
    {
      "id": "7fd82e03-09af-4b38-8d36-c7f7ec83cd99",
      "name": "Marketing Term Successes International.xlsx",
      "size": 17776,
      "parentReference": {
        "driveType": "personal",
        "driveId": "u-u-id-of-drive-containing-the-item"
        // no "id" because recipient is not allowed to see parent
      },
      "permissions": [
        {
          "@libre.graph.hidden": false,
          "id": "477731b4-56a6-4f58-9530-2e08bdf52df5",
          "roles": [
            "write"
          ],
          "grantedToV2": {
            "user": {
              "displayName": "Jörn Dreyer",
              "id": "c12644a14b0a7750"
            }
          }
        }
      ]
    },
    {
      "id": "a7d033f9-6093-43bb-91a7-bc82265e6a7f",
      "name": "Irrelevant Marketing Term Successes International.xlsx",
      "size": 176536587,
      "parentReference": {
        "driveType": "personal",
        "driveId": "u-u-id-of-drive-containing-the-item"
        // no "id" because recipient is not allowed to see parent
      },
      "permissions": [
        {
          "@libre.graph.hidden": true,
          "id": "5277be2e-db85-4d11-9a6c-28853142f279",
          "roles": [
            "write"
          ],
          "grantedToV2": {
            "user": {
              "displayName": "Jörn Dreyer",
              "id": "c12644a14b0a7750"
            }
          }
        }
      ]
    }
  ]
}
```
_jfd: we cannot put the `@libre.graph.hidden` property on the drive item directly, because it would mean the driveItem was hidden. So we put it on the permissions property. That hidden flag can be toggled._


## Accept/Reject a share / an invite
**OCS**:
- Accept `POST ocs/v2.php/apps/files_sharing/api/v1/shares/pending/{share-id}`
- Deny `DELETE ocs/v2.php/apps/files_sharing/api/v1/shares/pending/{share-id}`
**ms graph**: /sharedWithMe will list all shares, but
- I cannot see a property that shows the mountpoint ... the parentReference only contains
```json
"parentReference": {
    "driveId": "c12644a14b0a7750",
    "driveType": "personal"
},
```
**libre graph**: mount shares in the share jail by creating a driveItem using a `POST /drives/{sharejailid}/items` request:
```json
{
  "name": "Einsteins project share",
  "remoteItem": {
    "id": "{drive-item-id}"
  }
}
```
This request can check if the current user has access to the given drive item and will 'mount'/ accept it with the name "Einsteins project share".  In theory we could add a remoteItem anywhere in a drive like in OC10, but it is a product decision to collect them in the dedicated virtual share jail drive.

The mountpoint can be deleted/rejected by sending a `DELETE /drives/{drive-item-id}` where `{drive-item-id}` is the id of the drive item representing the mount point, not the remote item.


## Create a public link
**ms graph**
```json
POST /drives/{drive-id}/items/{drive-item-id}/createLink

{
    "type": "view",
    "scope": "anonymous"
}
```
response:
```json
{
    "id": "{permission-id}",
    "link": {
        "type": "view",
        "webUrl": "https://1drv.ms/f/s!AlB3CkuhRCbBgmde472f8-qxYdg",
        "application": {
            "id": "4c1ad100"
        }
    }
}
```

## Update shares / links
**ms graph**:
_jfd: same as libregraph but I tried changing the role ... we'll just not go there for now_
The role does affect the ui. It now shows upload elements even for non logged in users. The link type is still view. When trying to upload a file the web ui will try to log you in before making the request. The link type cannot be changed: in the UI there is a hint "This setting can't be changed. Create a new link if you need different permissions.". I guess this is to prevent changing permissions on existing links?

**libre graph**:
```json
PATCH /drives/{drive-id}/items/{drive-item-id}/permissions/{permission-id}

{
    "link": {
        "type": "edit"
    }
}
```

response
```json
{
    "id": "{permission-id}",
    "link": {
        "type": "edit",
        "webUrl": "https://1drv.ms/f/s!AlB3CkuhRCbBgmde472f8-qxYdg",
        "application": {
            "id": "4c1ad100"
        }
    }
}
```
For links we ignore the role and instead set the link type. ms graph has a lot predefined: https://learn.microsoft.com/en-us/graph/api/listitem-createlink?view=graph-rest-beta&tabs=http#link-types
<html><body>
<!--StartFragment-->

Type value | Description
-- | --
view | Creates a read-only link to the item.
review | Creates a review link to the item. This option is only available for files in OneDrive for Business and SharePoint.
edit | Creates an read-write link to the item.
embed | Creates an embeddable link to the item.
blocksDownload | Creates a read-only link that blocks  download to the item. This option is only available for files in  OneDrive for Business and SharePoint.
createOnly | Creates an upload-only link to the item. This option is only available for folders in OneDrive for Business and SharePoint.
addressBar | Creates the default link that is shown in  the browser address bars for newly created files. Only available in  OneDrive for Business and SharePoint. The organization admin configures  whether this link type is supported, and what features are supported by  this link type.
adminDefault | Creates the default link to the item as  determined by the administrator of the organization. Only available in  OneDrive for Business and SharePoint. The policy is enforced for the  organization by the admin

<!--EndFragment-->
</body>
</html>

## Delete shares / links
**OCS** `DELETE ocs/v1.php/apps/files_sharing/api/v1/shares/{share-id}`
**libre graph** `DELETE /drives/{drive-id}/items/{drive-item-id}/permissions/{permission-id}`

# older notes

- [x] `/drives/{drive-id}/items/{item-id}/invite` to create shares
- [x] `/drives/{drive-id}/items/{item-id}/createLink` to create links
- [x] `/me/drive/sharedWithMe` to list shares with the current user
- [x] `/me/drive/sharedByMe` to list shares by the current user. This only includes shares created by the current user, not all shares he can manage, eg. in project spaces.
- [ ] ~~extend `/drives` to allow `/drives?$expand=items&$filter=items/any(property:property/shared+ne+null)`, the listing of shares with others~~ we went with a libregraph only `/me/drive/sharedByMe` endpoint instead
  - Q: should this work for all spaces or only on a per space/drive basis? in project spaces, does a user want to see all shares in the space or only the ones he created? This request lists any driveItem that is shared aka that has a [`shared` facet](https://learn.microsoft.com/en-us/graph/api/resources/shared?view=graph-rest-1.0)
- [x] `/drives/{drive-id}/items/{item-id}/permissions` to list permissions
  - [x] get permission
  - [x] update permission
  - [x] delete permission
- [x] How do we make [the list of preconfigured roles](https://learn.microsoft.com/en-us/graph/api/resources/permission?view=graph-rest-1.0#roles-property-values) configurable?
  - ~~sharing roles as app roles / [appRoleAssignment](https://learn.microsoft.com/en-us/graph/api/resources/approleassignment?view=graph-rest-1.0) for a sharing app???~~
  - ~~a `sharing` relationship on the [`roleManagement` resource](https://learn.microsoft.com/en-us/graph/api/resources/rolemanagement?view=graph-rest-1.0#relationships) seems more fitting. appRoles are supposed to show up in access token scopes ... so ... nah~~
  - [x] clients want to be able discover the sharing roles that can be used for a specific driveItem
     - uses a collectiong annotation in the list permissions response at `/drives/{drive-id}/items/{item-id}/permissions`:
       ```
       {
          "@libre.graph.permissions.roles.allowedValues": [
            {
              "name": "read",
              "displayname": "Viewer"
            },
            {
              "name": "write",
              "displayname": "Editor"
            },
            {
              "name": "owner",
              "displayname": "Manager"
            }
          ],
          "value": [
             ...
          ]
       }
       ```
  - [x] /roleManagement/permissions/roleDefinitions
- [ ] ms graph has `/drives/{drive-id}/items/{item-id}/invite` and `/drives/{drive-id}/items/{item-id}/createLink`. They both add permissions to drive items and the `permission` object as a result can carry a `link` or a `grantedToV2` facet/property. This needs more investigation: permissioens have a `role` property but `link` objects themselves have a `type` ... and the existing [link types in ms graph](https://learn.microsoft.com/en-us/graph/api/driveitem-createlink?view=graph-rest-beta&tabs=http#link-types) pretty much cover all we need. That being said we want to have them customizeable ... so they should be discoverable, similar to the sharing roles at `/roleManagement/permissions/roleDefinitions`

## Further reading

It follows the MS Graph API, documented here:
* shares in ms graph are called permissions: https://learn.microsoft.com/en-us/graph/api/resources/permission?view=graph-rest-1.0
* invite is used to add permissions and optionally send a message https://learn.microsoft.com/en-us/graph/api/driveitem-invite?view=graph-rest-1.0&tabs=http
* list permissions on a driveItem: https://learn.microsoft.com/en-us/graph/api/driveitem-list-permissions?view=graph-rest-1.0&tabs=http
* get permission: https://learn.microsoft.com/en-us/graph/api/permission-get?view=graph-rest-1.0&tabs=http
* update permission: https://learn.microsoft.com/en-us/graph/api/permission-update?view=graph-rest-1.0&tabs=http
* delete permission: https://learn.microsoft.com/en-us/graph/api/permission-delete?view=graph-rest-1.0&tabs=http

* sharing roles are only read, view, owner: https://learn.microsoft.com/en-us/graph/api/resources/permission?view=graph-rest-1.0#roles-property-values

Listing shares incoming / outgoing shares:

* list shared with me https://learn.microsoft.com/en-us/graph/api/drive-sharedwithme
* list shared with others has no official andpoint, but the semantically matching request might be `https://graph.microsoft.com/v1.0/me/drive/items?$filter=shared ne null`. It works by matching all driveItems that have no sharing facet. However, it is not implemented in ms graph. Maybe because it is not clear that `/v1.0/me/drive/items` works on ALL drives. Semantically, it should only list the shared drive items on the users personal drive. To match drive items on all drives the user has access to `https://graph.microsoft.com/v1.0/drives?$expand=items&$filter=items/any(property:property/shared+ne+null)` could be used to get a list of all drives that have shared drive items and expand the items. This is not allowed on the ms graph api.
What does work is `https://graph.microsoft.com/v1.0/me/drive/root/search(q='*')?filter=shared+ne+null` but it is slow as it relies on the search() function. I'd go with the semantically correct version.

interesting sidenote
* creating sharing links: https://learn.microsoft.com/en-us/graph/api/driveitem-createlink?view=graph-rest-1.0&tabs=http
* there is a [`/shares/{share-id}` endpoint](https://learn.microsoft.com/en-us/graph/api/resources/shareddriveitem?view=graph-rest-1.0) that can be used to directly access a shared drive item ... similar to `/drives/{drive-id}` ... 🤔 

