### PR TITLE
Add libre-graph-api-php

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -23,6 +23,11 @@ config = {
 			'repo-slug': "libre-graph-api-cpp-qt-client",
 			'branch': 'main',
 		},
+		'php': {
+			'src': "out-php",
+			'repo-slug': "libre-graph-api-php",
+			'branch': 'main',
+		},
 	},
 	'openapi-generator-image': 'openapitools/openapi-generator-cli:v6.2.0@sha256:e6153ebc2f1a54985a50c53942e40285f1fbe64f1c701317da290bfff4abe303'
 }
@@ -39,7 +44,7 @@ def main(ctx):
 
 def stagePipelines(ctx):
 	linters = linting(ctx)
-	generators = generate(ctx, "go") + generate(ctx, "typescript-axios") + generate(ctx, "cpp-qt-client")
+	generators = generate(ctx, "go") + generate(ctx, "typescript-axios") + generate(ctx, "cpp-qt-client") + generate(ctx, "php")
 	dependsOn(linters, generators)
 	return linters + generators
 
@@ -257,6 +262,16 @@ def validate(lang):
 				"commands": [
 					"cd %s" % config["languages"][lang]["src"],
 					"golangci-lint run -v",
+				]
+			},
+		],
+		"php": [
+			{
+				"name": "validate-php",
+				"image": "owncloudci/php:8.0",
+				"commands": [
+					"composer install",
+					"vendor/bin/parallel-lint %s" % config["languages"][lang]["src"],
 				]
 			},
 		],

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/README.md
+++ b/README.md
@@ -37,5 +37,6 @@ That generates the output in out/cpp.
 ### Available client libraries
 - [C++/Qt](https://github.com/owncloud/libre-graph-api-cpp-qt-client)
 - [go](https://github.com/owncloud/libre-graph-api-go)
+- [php](https://github.com/owncloud/libre-graph-api-php)
 - [typescript-axios](https://github.com/owncloud/libre-graph-api-typescript-axios)
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "php-parallel-lint/php-parallel-lint": "^1.3"
+    }
+}


### PR DESCRIPTION
Add generated PHP for the libre-graph-api.

I used `php-parallel-lint` to verify that the generated PHP is valid syntax. The pipelines for other languages do similar linting. I suppose that is all that we can really do to get a "warm and fuzzy" that something was generated.
