### PR TITLE
Bump openapi-generator to v7.0.1

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -12,6 +12,7 @@ config = {
 			'src': "out-go",
 			'repo-slug': "libre-graph-api-go",
 			'branch': 'main',
+			'openapi-generator-image': 'openapitools/openapi-generator-cli:v6.6.0@sha256:08088a4625ebb8744b5cce414fe91396dbf8082e19aa32a44addcffc413dabde',
 		},
 		'typescript-axios': {
 			'src': "out-typescript-axios",
@@ -29,7 +30,7 @@ config = {
 			'branch': 'main',
 		},
 	},
-	'openapi-generator-image': 'openapitools/openapi-generator-cli:v7.0.1@sha256:1894bae95de139bd81b6fc2ba8d2e423a2bf1b0266518d175bd26218fe42a89b'
+	'openapi-generator-image': 'openapitools/openapi-generator-cli:v7.0.1@sha256:1894bae95de139bd81b6fc2ba8d2e423a2bf1b0266518d175bd26218fe42a89b',
 }
 
 def main(ctx):

--- a/.drone.star
+++ b/.drone.star
@@ -27,10 +27,9 @@ config = {
 			'src': "out-php",
 			'repo-slug': "libre-graph-api-php",
 			'branch': 'main',
-			'openapi-generator-image': 'openapitools/openapi-generator-cli:v7.0.0@sha256:08088a4625ebb8744b5cce414fe91396dbf8082e19aa32a44addcffc413dabde'
 		},
 	},
-	'openapi-generator-image': 'openapitools/openapi-generator-cli:v6.2.0@sha256:e6153ebc2f1a54985a50c53942e40285f1fbe64f1c701317da290bfff4abe303'
+	'openapi-generator-image': 'openapitools/openapi-generator-cli:v7.0.1@sha256:1894bae95de139bd81b6fc2ba8d2e423a2bf1b0266518d175bd26218fe42a89b'
 }
 
 def main(ctx):

--- a/.drone.star
+++ b/.drone.star
@@ -243,7 +243,7 @@ def validate(lang):
 		"go": [
 			{
 				"name": "go-fmt",
-				"image": "owncloudci/golang:1.17",
+				"image": "owncloudci/golang:1.18",
 				"commands": [
 					"cd %s" % config["languages"][lang]["src"],
 					"gofmt -w .",
@@ -251,7 +251,7 @@ def validate(lang):
 			},
 			{
 				"name": "go-mod",
-				"image": "owncloudci/golang:1.17",
+				"image": "owncloudci/golang:1.18",
 				"commands": [
 					"cd %s" % config["languages"][lang]["src"],
 					"go mod tidy",


### PR DESCRIPTION
I would like to use the generated `ToMap` function of models (in go) which has been added after v6.2.0

## go
`openapi-generator:7.0.x` introduces breaking changes in the go code. 
1) required go version is bumped from 1.17 to 1.18
2) I needed to make these adjustments in the oCIS code base:

```diff
diff --git a/services/proxy/pkg/user/backend/cs3.go b/services/proxy/pkg/user/backend/cs3.go
index 70cb9cb8a4..aea2d4cebf 100644
--- a/services/proxy/pkg/user/backend/cs3.go
+++ b/services/proxy/pkg/user/backend/cs3.go
@@ -175,7 +175,7 @@ func (c *cs3backend) CreateUserFromClaims(ctx context.Context, claims map[string
                return nil, fmt.Errorf("Error creating user from claims: %w", err)
        }
 
-       req := lgClient.UsersApi.CreateUser(newctx).User(newUser)
+       req := lgClient.UsersAPI.CreateUser(newctx).User(newUser)
 
        created, resp, err := req.Execute()
        defer resp.Body.Close()
@@ -202,7 +202,7 @@ func (c *cs3backend) CreateUserFromClaims(ctx context.Context, claims map[string
        // User has been created meanwhile, re-read it to get the user id
        if reread {
                c.logger.Debug().Msg("User already exist, re-reading via libregraph")
-               gureq := lgClient.UserApi.GetUser(newctx, newUser.GetOnPremisesSamAccountName())
+               gureq := lgClient.UserAPI.GetUser(newctx, newUser.GetOnPremisesSamAccountName())
                created, resp, err = gureq.Execute()
                defer resp.Body.Close()
                if err != nil {
```

That's why I've bumped the `openapi-generator-image` only to `v6.6.0` for go, which already contains the `ToMap` function I want to use, but doesn't contain the Api -> API renames. The go version is still bumped to 1.18 - do you think that's acceptable?

## typescript-axios
I don't think the API changes are breaking (just fancier ways to express types), at least no changes in oC Web are needed.

## PHP
Is using 7.0 already and there are no changes except for the version number.

## C++/Qt
As we are using our own templates, no changes