### PR TITLE
Switch go to openapi-generator 7

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -18,19 +18,16 @@ config = {
 			'src': "out-typescript-axios",
 			'repo-slug': "libre-graph-api-typescript-axios",
 			'branch': 'main',
-			'generator-args': "",
 		},
 		'cpp-qt-client': {
 			'src': "out-cpp-qt-client",
 			'repo-slug': "libre-graph-api-cpp-qt-client",
 			'branch': 'main',
-			'generator-args': "",
 		},
 		'php': {
 			'src': "out-php",
 			'repo-slug': "libre-graph-api-php",
 			'branch': 'main',
-			'generator-args': "",
 		},
 	},
 	'openapi-generator-image': 'openapitools/openapi-generator-cli:v7.0.1@sha256:1894bae95de139bd81b6fc2ba8d2e423a2bf1b0266518d175bd26218fe42a89b',
@@ -168,7 +165,7 @@ def generate(ctx, lang):
 				'commands': [
 					'test -d "templates/{0}" && TEMPLATE_ARG="-t templates/{0}" || TEMPLATE_ARG=""'.format(lang),
 					'rm -Rf %s/*' % config["languages"][lang]["src"],
-					'/usr/local/bin/docker-entrypoint.sh generate --enable-post-process-file -i api/openapi-spec/v1.0.yaml $${TEMPLATE_ARG} --additional-properties=packageName=libregraph --git-user-id=owncloud --git-repo-id=%s -g %s -o %s %s' % (config["languages"][lang]["repo-slug"], lang, config["languages"][lang]["src"], config["languages"][lang]["generator-args"]),
+					'/usr/local/bin/docker-entrypoint.sh generate --enable-post-process-file -i api/openapi-spec/v1.0.yaml $${TEMPLATE_ARG} --additional-properties=packageName=libregraph --git-user-id=owncloud --git-repo-id=%s -g %s -o %s %s' % (config["languages"][lang]["repo-slug"], lang, config["languages"][lang]["src"], config["languages"][lang].get('generator-args', '') ),
 					'cp LICENSE %s/LICENSE' % config["languages"][lang]["src"],
 				],
 			}

--- a/.drone.star
+++ b/.drone.star
@@ -12,21 +12,25 @@ config = {
 			'src': "out-go",
 			'repo-slug': "libre-graph-api-go",
 			'branch': 'main',
+			'generator-args': "--api-name-suffix Api",
 		},
 		'typescript-axios': {
 			'src': "out-typescript-axios",
 			'repo-slug': "libre-graph-api-typescript-axios",
 			'branch': 'main',
+			'generator-args': "",
 		},
 		'cpp-qt-client': {
 			'src': "out-cpp-qt-client",
 			'repo-slug': "libre-graph-api-cpp-qt-client",
 			'branch': 'main',
+			'generator-args': "",
 		},
 		'php': {
 			'src': "out-php",
 			'repo-slug': "libre-graph-api-php",
 			'branch': 'main',
+			'generator-args': "",
 		},
 	},
 	'openapi-generator-image': 'openapitools/openapi-generator-cli:v7.0.1@sha256:1894bae95de139bd81b6fc2ba8d2e423a2bf1b0266518d175bd26218fe42a89b',
@@ -164,7 +168,7 @@ def generate(ctx, lang):
 				'commands': [
 					'test -d "templates/{0}" && TEMPLATE_ARG="-t templates/{0}" || TEMPLATE_ARG=""'.format(lang),
 					'rm -Rf %s/*' % config["languages"][lang]["src"],
-					'/usr/local/bin/docker-entrypoint.sh generate --enable-post-process-file -i api/openapi-spec/v1.0.yaml $${TEMPLATE_ARG} --additional-properties=packageName=libregraph --git-user-id=owncloud --git-repo-id=%s -g %s -o %s' % (config["languages"][lang]["repo-slug"], lang, config["languages"][lang]["src"]),
+					'/usr/local/bin/docker-entrypoint.sh generate --enable-post-process-file -i api/openapi-spec/v1.0.yaml $${TEMPLATE_ARG} --additional-properties=packageName=libregraph --git-user-id=owncloud --git-repo-id=%s -g %s -o %s %s' % (config["languages"][lang]["repo-slug"], lang, config["languages"][lang]["src"], config["languages"][lang]["generator-args"]),
 					'cp LICENSE %s/LICENSE' % config["languages"][lang]["src"],
 				],
 			}

--- a/.drone.star
+++ b/.drone.star
@@ -12,7 +12,6 @@ config = {
 			'src': "out-go",
 			'repo-slug': "libre-graph-api-go",
 			'branch': 'main',
-			'openapi-generator-image': 'openapitools/openapi-generator-cli:v6.6.0@sha256:08088a4625ebb8744b5cce414fe91396dbf8082e19aa32a44addcffc413dabde',
 		},
 		'typescript-axios': {
 			'src': "out-typescript-axios",


### PR DESCRIPTION
We stayed on 6.6.0 to avoid a breaking change, but apparently the breaking change (Api -> API in generated struct names) seems to have been introduced before 7 already. So after a quick discussion we decided to accept this breaking change.