### PR TITLE
remove type of the innererror

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4195,7 +4195,6 @@ components:
           items:
             $ref: '#/components/schemas/odata.error.detail'
         innererror:
-          type: object
           description: The structure of this object is service-specific
     odata.error.detail:
       required:


### PR DESCRIPTION
With the type set I get a problem with php(next-gen) code, because the deserelizer returns an array, but then expects an object as the error.
Do we strictly need the type here?