### PR TITLE
feat(api): Add missing setPassword endpoint to sharing NG

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4040,7 +4040,7 @@ components:
       properties:
         password:
           type: string
-          description: Password. It may reuquire a password policy.
+          description: Password. It may require a password policy.
     audio:
       type: object
       description: |

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -902,6 +902,88 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/v1beta1/drives/{drive-id}/items/{item-id}/permissions/{perm-id}/setPassword':
+    post:
+      tags:
+        - drives.permissions
+      summary: Set sharing link password
+      operationId: SetPermissionPassword
+      description: |
+        Set the password of a sharing permission.
+
+        Only the `password` property can be modified this way.
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: 'key: id of item'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: item
+        - name: perm-id
+          in: path
+          description: 'key: id of permission'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: permission
+        #- name: If-Match
+        #  in: header
+        #  description: |
+        #    If this request header is included and the eTag (or cTag) provided does not match the current tag on the item,
+        #    a `412 Precondition Failed`` response is returned and the item will not be updated.
+        #  schema:
+        #    type: string
+      requestBody:
+        description: New password value
+        content:
+          application/json:
+              schema:
+                $ref: '#/components/schemas/sharingLinkPassword'
+              examples:
+                  set password:
+                    value:
+                      password: "TestPassword123!"
+                  set empty password:
+                    value:
+                      password: ""
+        required: true
+      responses:
+        '200':
+          description: Updated permission
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/permission'
+              examples:
+                set password on editor link with custom display name:
+                  value:
+                    - id: "7181275c-557e-4adf-8e44-abdcf5389b6a"
+                      hasPassword: true
+                      expirationDateTime: "2018-07-15T14:00:00.000Z"
+                      link:
+                        type: "edit"
+                        displayName: "Homework"
+                        webUrl: "https://cloud.example.org/s/fdleMyGeerkIZTJ"
+                set empty password:
+                  value:
+                    - id: "765c9b7b-6ccf-46ff-a659-95501250229c"
+                      hasPassword: false
+                      link:
+                        type: "view"
+                        displayName: "Quick link"
+                        quicklink: true
+                        webUrl: "https://cloud.example.org/s/erjHgjKjkstTesG"
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   '/v1.0/drives/{drive-id}/root':
     get:
       tags:
@@ -3951,6 +4033,14 @@ components:
         #    Details of any associated sharing invitation for this permission. For now only used when creating shares with
         #    internal users or groups. An invitation is converted into a grant and will not be part of responses.
         #  $ref: '#/components/schemas/sharingInvitation'
+    sharingLinkPassword:
+      type: object
+      description: |
+        The sharing link password which should be set.
+      properties:
+        password:
+          type: string
+          description: Password. It may reuquire a password policy.
     audio:
       type: object
       description: |


### PR DESCRIPTION
# Description

In ocis we allow more than one link per resource. As a consequence we need a dedicated call to set a  password on an existing link.

Relates to https://github.com/owncloud/libre-graph-api/issues/136

## Swagger UI

![1700470197271](https://github.com/owncloud/libre-graph-api/assets/4378513/bd0b9280-0401-470e-9476-0f41d752c617)
