### PR TITLE
Fix response type for POST '/v1beta1/drives/{drive-id}/items/{item-id}/invite'

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -476,7 +476,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/permission'
+                title: Collection of permissions
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/permission'
               examples:
                 send viewer invite:
                   value:
@@ -602,7 +608,7 @@ paths:
           content:
             application/json:
               schema:
-                title: Collection of permissions
+                title: Collection of permissions with allowed values
                 type: object
                 properties:
                   '@libre.graph.permissions.roles.allowedValues':


### PR DESCRIPTION
We need to return a collection of permissions

Fixes: #138