### PR TITLE
fix(api): Make the expiration date nullable

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -3993,6 +3993,7 @@ components:
           type: string
           description: An optional expiration date which limits the permission in time.
           format: date-time
+          nullable: true
         grantedToV2:
         # this is always a single identity set because a permission always is tied to a single recipient (which can be a group).
           description: For user type permissions, the details of the users and applications for this permission. Only part of responses. Use the invitation property when creating shares.


### PR DESCRIPTION
# Description

In order to "unset" an expiration date, we need a nullable dateTime type.