### PR TITLE
return 201 on successfull invite

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -471,7 +471,7 @@ paths:
                     - objectId: "4c510ada-c86b-4815-8820-42cdf82c3d51"
                     '@libre.graph.permissions.actions': [ "libre.graph/driveItem/basic/read", "libre.graph/driveItem/path/update" ]
       responses:
-        '200':
+        '201':
           description: Response
           content:
             application/json:


### PR DESCRIPTION
currently ocis returns 201 and not 200 when the invite is successfull, I think that is correct so adjust the API definition
