### PR TITLE
add mount and unmount example

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -365,6 +365,97 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/v1beta1/drives/{drive-id}/root/children':
+    post:
+      tags:
+        - drives.root
+      summary: Create a drive item
+      operationId: CreateDriveItem
+      description: |
+        You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true.
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668
+          x-ms-docs-key-type: drive
+      requestBody:
+        description: In the request body, provide a JSON object with the following parameters. For mounting a share the necessary remoteItem id and permission id can be taken from the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/driveItem'
+            example:
+              name: Einsteins project share
+              remoteItem:
+                id: a-storage-provider-id$a-space-id!a-node-id
+                permissions:
+                  - id: share-id
+      responses:
+        '200':
+          description: Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/driveItem'
+              example:
+                name: Einsteins project share
+                id: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
+                remoteItem:
+                  id: a-storage-provider-id$a-space-id!a-node-id
+                  name: Project
+                parentReference:
+                  driveID: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668
+                  id: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!a0ca6a90-a365-4782-871e-d44447bbc668
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+      
+  '/v1beta1/drives/{drive-id}/items/{item-id}':
+    delete:
+      tags:
+        - driveItem
+      summary: Delete a DriveItem.
+      operationId: DeleteDriveItem
+      description: |
+        Delete a DriveItem by using its ID.
+        
+        Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item.
+        
+        Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false.
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: 'key: id of item'
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
+          x-ms-docs-key-type: item
+        #- name: If-Match
+        #  in: header
+        #  description: |
+        #    If this request header is included and the eTag (or cTag) provided does not match the current tag on the item,
+        #    a `412 Precondition Failed`` response is returned and the item will not be updated.
+        #  schema:
+        #    type: string
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   '/v1beta1/drives/{drive-id}/items/{item-id}/createLink':
     post:
       tags:


### PR DESCRIPTION
This adds the necessary endpoints for mounting and unmounting shares.

Since the endpoints could be implemented for all drives I left the `{drive-id}` parameter in. The server implementation can check if it is the share jail id and return a not implemented error for all other drives.

Mounting happens by POSTing a new driveItem to the root children collection:
```http
POST /v1beta1/drives/a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668/root/children
ContentType: application/json

{
  "name": "Einsteins project share",
  "remoteItem": {
    "id": "a-storage-provider-id$a-space-id!a-node-id",
    "permissions": [
      {
        "id": "share-id"
      }
    ]
  }
}
```
The necessary ids can be taken from the output of the `/me/drives/sharedWithMe` endpoint

Unmounting happens by DELETEing the driveItem in the sharejail:
```http
DELETE /v1beta1/drives/a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668/items/a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
```
