### PR TITLE
Revert "enhancement: move ui hidden and client synchronize to the remote

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4004,13 +4004,6 @@ components:
           type: string
           description: URL that displays the resource in the browser. Read-only.
           title: shared
-        '@client.synchronize':
-            description: Indicates if the item is synchronized with the underlying storage provider. Read-only.
-            type: boolean
-          # follows the SAP UI vocabulary: https://github.com/SAP/odata-vocabularies/blob/main/vocabularies/UI.md
-        '@ui.hidden':
-            description: Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true. Users can set this to hide permissons.
-            type: boolean
     shared:
       type: object
       properties:
@@ -4172,6 +4165,14 @@ components:
           type: array
           items:
             type: string
+        '@client.synchronize':
+            description: Indicates if the item is synchronized with the underlying storage provider. Read-only.
+            type: boolean
+        # follows the SAP UI vocabulary: https://github.com/SAP/odata-vocabularies/blob/main/vocabularies/UI.md
+        '@ui.hidden':
+          description: Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true. Users can set this to hide permissons.
+          type: boolean
+
         # unused. We could put public link token in here, but we currently only need the link property, anyway
         #shareId:
         #  description: A unique token that can be used to access this shared item via the shares API.


### PR DESCRIPTION
This reverts commit 8b02656aab4959377e61fa470ef51aba820a7e0d. Moving the `ui.hidden` and `client.synchronize` back to the `permissions` property.

This might be unpopular, but IMO it's the cleaner solution for now. If we really want to group multiple shares of the same resource into a single `driveItem`/`remoteItem` response we first need to think about how we make that compatible with our current backend.

Magically merging these into a single attribute on the frontend is not enough IMO. We also need to find a stable id to set for such a share as the `id` value of the outer driveitem. Currently that `id` is derived from the `sharedId`. Which doesn't work anymore once there are multiple shares for the some resource.