### PR TITLE
Adapt shareWithMe specifcation to be able to group shares by shared resource

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -3990,8 +3990,6 @@ components:
           readOnly: true
         parentReference:
           $ref: '#/components/schemas/itemReference'
-        shared:
-          $ref: '#/components/schemas/shared'
         permissions:
           type: array
           items:
@@ -4011,21 +4009,6 @@ components:
           type: string
           description: URL that displays the resource in the browser. Read-only.
           title: shared
-    shared:
-      type: object
-      properties:
-        owner:
-          $ref: '#/components/schemas/identitySet'
-        scope:
-          type: string
-          description: 'Indicates the scope of how the item is shared: anonymous, organization, or users. Read-only.'
-        sharedBy:
-          $ref: '#/components/schemas/identitySet'
-        sharedDateTime:
-          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
-          type: string
-          description: The UTC date and time when the item was shared. Read-only.
-          format: date-time
     quota:
       type: object
       description: Optional. Information about the drive's storage space quota. Read-only.
@@ -4172,6 +4155,10 @@ components:
           type: array
           items:
             type: string
+        invitation:
+          description: |
+            Details of any associated sharing invitation for this permission.
+          $ref: '#/components/schemas/sharingInvitation'
 
         # unused. We could put public link token in here, but we currently only need the link property, anyway
         #shareId:
@@ -4187,11 +4174,14 @@ components:
         #    $ref: '#/components/schemas/sharePointIdentitySet'
 
         # unused. invites are created with the driveItemInvite resource
-        #invitation:
-        #  description: |
-        #    Details of any associated sharing invitation for this permission. For now only used when creating shares with
-        #    internal users or groups. An invitation is converted into a grant and will not be part of responses.
-        #  $ref: '#/components/schemas/sharingInvitation'
+    sharingInvitation:
+      type: object
+      description: |
+        invitation-related data items
+      properties:
+        invitedBy:
+          description: Provides information about who sent the invitation that created this permission, if that information is available. Read-only.
+          $ref: '#/components/schemas/identitySet'
     sharingLinkPassword:
       type: object
       description: |

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -1615,7 +1615,12 @@ paths:
               example:
                 value:
                   - id: 78363031-03ef-4eda-84a2-243a691a13cd
-                    createdDateTime: "2020-02-19T14:23:25.52Z"
+                    '@UI.hidden': false
+                    '@client.synchronize': true
+                    createdBy:
+                      user:
+                        displayName: "Albert Einstein"
+                        id: "44feab10d55e9871"
                     cTag: "adDpDMTI2NDRBMTRCMEE3NzUwITEzNzkuNjM3NjYyNzQ5NjU1MDMwMDAw"
                     eTag: "aQzEyNjQ0QTE0QjBBNzc1MCExMzc5LjQ"
                     lastModifiedDateTime: "2021-09-03T14:09:25.503Z"
@@ -1627,12 +1632,20 @@ paths:
                       id: 02d7a7df-a6f7-44cc-848a-3c98f7dd5046
                       name: "March Proposal.docx"
                       size: 19121
-                      shared:
-                        sharedDateTime: "2020-02-19T14:23:25.52Z"
-                        owner:
-                          user:
-                            displayName: "Albert Einstein"
-                            id: "44feab10d55e9871"
+                      lastModifiedDateTime: "2021-09-03T14:09:25.503Z"
+                      permissions:
+                        - id: 7310e99f-377b-4cba-a1f0-ffa3331fd32c
+                          roles:
+                            - b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5
+                          grantedToV2: 
+                            group:
+                              displayName: "users"
+                              id: 509a9dcd-bb37-4f4f-a01a-19dca27d9cfa
+                          invitation:
+                            invitedBy:
+                              user:
+                                displayName: "Albert Einstein"
+                                id: "44feab10d55e9871"
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -372,7 +372,7 @@ paths:
       summary: Create a drive item
       operationId: CreateDriveItem
       description: |
-        You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true.
+        You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `driveItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true.
       parameters:
         - name: drive-id
           in: path
@@ -425,7 +425,7 @@ paths:
         
         Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item.
         
-        Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false.
+        Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `driveItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false.
       parameters:
         - name: drive-id
           in: path
@@ -3668,6 +3668,13 @@ components:
         video:
           description: Video metadata, if the item is a video. Read-only.
           $ref: '#/components/schemas/video'
+        '@client.synchronize':
+            description: Indicates if the item is synchronized with the underlying storage provider. Read-only.
+            type: boolean
+        # follows the SAP UI vocabulary: https://github.com/SAP/odata-vocabularies/blob/main/vocabularies/UI.md
+        '@UI.Hidden':
+          description: Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true. Users can set this to hide permissons.
+          type: boolean
     sharingLinkType:
         type: string
         enum: [internal, view, upload, edit, createOnly, blocksDownload]
@@ -4165,13 +4172,6 @@ components:
           type: array
           items:
             type: string
-        '@client.synchronize':
-            description: Indicates if the item is synchronized with the underlying storage provider. Read-only.
-            type: boolean
-        # follows the SAP UI vocabulary: https://github.com/SAP/odata-vocabularies/blob/main/vocabularies/UI.md
-        '@ui.hidden':
-          description: Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true. Users can set this to hide permissons.
-          type: boolean
 
         # unused. We could put public link token in here, but we currently only need the link property, anyway
         #shareId:


### PR DESCRIPTION
- Move the `UI.Hidden` and `client.synchronize` flags to the outer drive item
- add `invitation` property to `permissions`  (to expose the share creator)
- remove `shared` property from `remoteItem`. With the share creator information move to `permssion` this can go away.
- adjust examples accordingly