### PR TITLE
fix: return a drive item after the drive item update

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -1121,6 +1121,10 @@ paths:
       responses:
         '200':
           description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/driveItem'
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation


### PR DESCRIPTION
the update drive item endpoint now returns the updated drive item