### PR TITLE
feat: add documentation for drive items GET endpoint

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -1076,6 +1076,40 @@ paths:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
   '/v1beta1/drives/{drive-id}/items/{item-id}':
+    get:
+      tags:
+        - driveItem
+      summary: Get a DriveItem.
+      operationId: GetDriveItem
+      description: |
+        Get a DriveItem by using its ID.
+      parameters:
+        - name: drive-id
+          in: path
+          description: "key: id of drive"
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: "key: id of item"
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
+          x-ms-docs-key-type: item
+      responses:
+        "200":
+          description: Retrieved driveItem
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/driveItem"
+        default:
+          $ref: "#/components/responses/error"
+      x-ms-docs-operation-type: operation
     patch:
       tags:
         - driveItem


### PR DESCRIPTION
Documents the endpoint for getting drive items via ID as implemented via https://github.com/owncloud/ocis/pull/8939/commits/ad016b1fc4fbd0e033c7f1bff4e8dfc2f02e4a79.