### PR TITLE
Add Basic auth to the supported security schemes

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5512,6 +5512,10 @@ components:
       type: http
       scheme: bearer
       bearerFormat: plain
+    basicAuth:
+      description: HTTP Basic Authentication (discouraged for production environments)
+      type: http
+      scheme: basic
   examples:
     tags_put:
       value:
@@ -5582,3 +5586,4 @@ components:
         externalId: ac528aea-978e-415c-a733-c4ba235d3388
 security:
   - openId: [ ]
+  - basicAuth: [ ]


### PR DESCRIPTION
We still support basic auth and without this in the spec the generated go client will not include support for it.