### PR TITLE
Fix request body for UpdateDrive

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -306,7 +306,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/drive'
+              $ref: '#/components/schemas/driveUpdate'
             examples:
               change quota:
                 value:
@@ -4035,9 +4035,13 @@ components:
           description: 'The user`s type. This can be either "Member" for regular user, or "Guest" for guest users.'
     drive:
       description: The drive represents a space on the storage.
-      type: object
       required:
         - name
+      allOf:
+        - $ref: '#/components/schemas/driveUpdate'
+    driveUpdate:
+      description: The drive represents an update to a space on the storage.
+      type: object
       properties:
         # entity
         id:


### PR DESCRIPTION
The UpdateDrive request does not require the 'name' property. It is only required for creating a drive. We fixed this by introducing a new type 'driveUpdate' with 'name' as an optional property and deriving the 'drive' type from it with 'name' as a required property.

This is needed because the latest release of the code generator for go now does some basic validation for required attributes.