### PR TITLE
chore: fix primaryRole spelling in examples

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -3187,7 +3187,7 @@ paths:
                   surname: Mustermann
                   givenName: Max
                   mail: max.musterman@example.org
-                  primariyRole: student
+                  primaryRole: student
                   identities:
                     - issuer: idp.school.com
                       issuerAssignedId: max.mustermann
@@ -3547,7 +3547,7 @@ paths:
                   surname: Mustermann
                   givenName: Max
                   mail: max.musterman@example.org
-                  primariyRole: student
+                  primaryRole: student
                   identities:
                     - issuer: idp.school.com
                       issuerAssignedId: max.mustermann
@@ -3649,7 +3649,7 @@ paths:
                   surname: Mustermann
                   givenName: Max
                   mail: max.musterman@example.org
-                  primariyRole: teacher
+                  primaryRole: teacher
                   identities:
                     - issuer: idp.school.com
                       issuerAssignedId: max.mustermann


### PR DESCRIPTION
One of the education user properties is `primaryRole` (not `primariyRole`)
