### PR TITLE
Add "Federated" as a new user type

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4074,7 +4074,7 @@ components:
           description: 'The user`s default role. Such as "student" or "teacher"'
         userType:
           type: string
-          description: 'The user`s type. This can be either "Member" for regular user, or "Guest" for guest users.'
+          description: 'The user`s type. This can be either "Member" for regular user, "Guest" for guest users or "Federated" for users imported from a federated instance.'
     drive:
       description: The drive represents a space on the storage.
       required:
@@ -4353,7 +4353,7 @@ components:
           description: The user's givenName. Returned by default.
         userType:
           type: string
-          description: 'The user`s type. This can be either "Member" for regular user, or "Guest" for guest users.'
+          description: 'The user`s type. This can be either "Member" for regular user, "Guest" for guest users or "Federated" for users imported from a federated instance.'
         preferredLanguage:
           $ref: '#/components/schemas/language'
     itemReference:


### PR DESCRIPTION
This is needed for "OCM" integration in ocis. To be able to differentiate user's accepted via OCM from normal member users.