### PR TITLE
Mark user properties `userType` and `memberOf` as read-only

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4350,6 +4350,7 @@ components:
           items:
             $ref: '#/components/schemas/group'
           description: 'Groups that this user is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
+          readOnly: true
         onPremisesSamAccountName:
           type: string
           description: 'Contains the on-premises SAM account name synchronized from the on-premises directory.'
@@ -4364,6 +4365,7 @@ components:
         userType:
           type: string
           description: 'The user`s type. This can be either "Member" for regular user, "Guest" for guest users or "Federated" for users imported from a federated instance.'
+          readOnly: true
         preferredLanguage:
           $ref: '#/components/schemas/language'
     itemReference:


### PR DESCRIPTION
We don't want 'userType' to be set on POST/PATCH requests for now. Currenly users with a type different from 'Member' are created either via ocm or via graph invite requests.
See: https://github.com/owncloud/ocis/issues/9858 for details

Also 'memberOf' is a read-only relation in MS Graph.