### PR TITLE
Add 'signinActivity' to user

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4298,6 +4298,14 @@ components:
         #    | organization   | Anyone signed into your organization (tenant) can use the link to get access.                                         |
         #    | existingAccess | Only people who have already been granted access to the item through other means can access the item using this link. |
         #    | users          | The link grants access only to a specific list of people.                                                             |
+    signInActivity:
+      description: Provides the last successful sign-in attempt for a user
+      type: object
+      properties:
+        lastSuccessfulSignInDateTime:
+          type: string
+          format: date-time
+          description: The date and time of the last successful sign-in for the user.
     user:
       description: Represents an Active Directory user object.
       required:
@@ -4368,6 +4376,9 @@ components:
           readOnly: true
         preferredLanguage:
           $ref: '#/components/schemas/language'
+        signInActivity:
+          readOnly: true
+          $ref: '#/components/schemas/signInActivity'
     itemReference:
       type: object
       properties:


### PR DESCRIPTION
Current plan is to only provide the `lastSuccessfulSignInDateTime` property.

Needed for: https://github.com/owncloud/enterprise/issues/6726