### PR TITLE
fix: make instance properties required

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5681,6 +5681,9 @@ components:
       type: object
       title: instance
       description: 'An oCIS instance that the user is either a member or a guest of.'
+      required:
+        - url
+        - primary
       properties:
         url:
           type: string


### PR DESCRIPTION
All of the current properties of instance object are required. Add the required array and include all of them to mark them accordingly.