### PR TITLE
fix(spec): ListPermissionRoleDefinitions returns an array of roleDefinitions

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -3971,43 +3971,44 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/unifiedRoleDefinition'
+                type: array
+                items:
+                  $ref: '#/components/schemas/unifiedRoleDefinition'
               example:
-                value:
-                  - id: b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5
-                    description: "Allows reading the shared file or folder"
-                    displayName: Viewer
-                    rolePermissions:
-                      - allowedResourceActions:
-                          - libre.graph/driveItem/basic/read
-                          - libre.graph/driveItem/permissions/read
-                          - libre.graph/driveItem/upload/create
-                        condition: "exists @Resource.File"
-                    '@libre.graph.weight': 1
-                  - id: fb6c3e19-e378-47e5-b277-9732f9de6e21
-                    description: "Allows reading and writing the shared file or folder"
-                    displayName: Editor
-                    rolePermissions:
-                      - allowedResourceActions:
-                          - libre.graph/driveItem/standard/allTasks
-                        condition: "exists @Resource.File"
-                    '@libre.graph.weight': 2
-                  - id: 312c0871-5ef7-4b3a-85b6-0e4074c64049
-                    description: "Allows managing a space"
-                    displayName: Manager
-                    rolePermissions:
-                      - allowedResourceActions:
-                          - libre.graph/drive/standard/allTasks
-                        condition: "exists @Resource.File"
-                    '@libre.graph.weight': 3
-                  - id: 4916f47e-66d5-49bb-9ac9-748ad00334b
-                    description: "Allows creating new files"
-                    displayName: File Drop
-                    rolePermissions:
-                      - allowedResourceActions:
-                          libre.graph/driveItem/upload/create
-                        condition: "exists @Resource.File"
-                    '@libre.graph.weight': 4
+                - id: b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5
+                  description: "Allows reading the shared file or folder"
+                  displayName: Viewer
+                  rolePermissions:
+                    - allowedResourceActions:
+                        - libre.graph/driveItem/basic/read
+                        - libre.graph/driveItem/permissions/read
+                        - libre.graph/driveItem/upload/create
+                      condition: "exists @Resource.File"
+                  '@libre.graph.weight': 1
+                - id: fb6c3e19-e378-47e5-b277-9732f9de6e21
+                  description: "Allows reading and writing the shared file or folder"
+                  displayName: Editor
+                  rolePermissions:
+                    - allowedResourceActions:
+                        - libre.graph/driveItem/standard/allTasks
+                      condition: "exists @Resource.File"
+                  '@libre.graph.weight': 2
+                - id: 312c0871-5ef7-4b3a-85b6-0e4074c64049
+                  description: "Allows managing a space"
+                  displayName: Manager
+                  rolePermissions:
+                    - allowedResourceActions:
+                        - libre.graph/drive/standard/allTasks
+                      condition: "exists @Resource.File"
+                  '@libre.graph.weight': 3
+                - id: 4916f47e-66d5-49bb-9ac9-748ad00334b
+                  description: "Allows creating new files"
+                  displayName: File Drop
+                  rolePermissions:
+                    - allowedResourceActions:
+                        libre.graph/driveItem/upload/create
+                      condition: "exists @Resource.File"
+                  '@libre.graph.weight': 4
         default:
           $ref: '#/components/responses/error'
   /v1beta1/roleManagement/permissions/roleDefinitions/{role-id}:


### PR DESCRIPTION
## Problem

The `GET /v1beta1/roleManagement/permissions/roleDefinitions` (`ListPermissionRoleDefinitions`) operation declares its `200` response schema as a **single** `unifiedRoleDefinition`:

```yaml
schema:
  $ref: '#/components/schemas/unifiedRoleDefinition'
example:
  value:
    - id: ...
```

But the endpoint returns a **JSON array** of role definitions (verified against a live oCIS 8.0.1 — the body starts with `[{ ... }, ...]`). Two problems follow:

1. Generated clients fail to decode the response. The Go client's `Execute()` returns `*UnifiedRoleDefinition` and json-decodes the whole array-body into a single struct, which errors — so the method is unusable (downstream has to hand-roll this endpoint; see owncloud/libre-graph-api-go#10 and owncloud/ocis-mcp-server#24).
2. The schema and the example disagree (singular object vs a `value:`-wrapped array), and both disagree with the live bare-array response.

## Fix

Make the `200` response an array and correct the example to a bare array:

```yaml
schema:
  type: array
  items:
    $ref: '#/components/schemas/unifiedRoleDefinition'
example:
  - id: ...
```

The singular `GET .../roleDefinitions/{role-id}` (`GetPermissionRoleDefinition`) is unchanged — it correctly returns one object.

## Verification

- `openapi-generator-cli v7.8.0 validate -i api/openapi-spec/v1.0.yaml` → **No validation issues detected**.
- Regenerated the Go client from this spec: `func (r ApiListPermissionRoleDefinitionsRequest) Execute() ([]UnifiedRoleDefinition, *http.Response, error)` with `localVarReturnValue []UnifiedRoleDefinition` — the list now decodes correctly.

Fixes owncloud/libre-graph-api-go#10